### PR TITLE
Enable LCP audiobooks

### DIFF
--- a/NYPLAudiobookToolkit/Core/Audiobook.swift
+++ b/NYPLAudiobookToolkit/Core/Audiobook.swift
@@ -58,6 +58,8 @@ import UIKit
         let possibleScheme = drm?["scheme"] as? String
         let audiobook: Audiobook?
         print("Breakpoint 1: JSON: \(JSON)")
+        return LCPAudiobook(JSON: JSON, decryptor: decryptor)
+
         if let scheme = possibleScheme {
             switch scheme {
             case "http://librarysimplified.org/terms/drm/scheme/FAE":

--- a/NYPLAudiobookToolkit/Core/Audiobook.swift
+++ b/NYPLAudiobookToolkit/Core/Audiobook.swift
@@ -57,38 +57,24 @@ import UIKit
         let drm = metadata?["encrypted"] as? [String: Any]
         let possibleScheme = drm?["scheme"] as? String
         let audiobook: Audiobook?
-        print("Breakpoint 1: JSON: \(JSON)")
 
-        if let scheme = possibleScheme {
-            switch scheme {
-            case "http://librarysimplified.org/terms/drm/scheme/FAE":
-                let FindawayAudiobookClass = NSClassFromString("NYPLAEToolkit.FindawayAudiobook") as? Audiobook.Type
-                audiobook = FindawayAudiobookClass?.init(JSON: JSON)
-            case "http://readium.org/2014/01/lcp":
-                audiobook = LCPAudiobook(JSON: JSON, decryptor: decryptor)
-            default:
-                if let type = JSON["formatType"] as? String,
-                    type == "audiobook-overdrive" {
-                        audiobook = OverdriveAudiobook(JSON: JSON)
-                } else if let manifestContext = JSON["@context"] as? String, manifestContext == LCPAudiobook.manifestContext {
-                    audiobook = LCPAudiobook(JSON: JSON, decryptor: decryptor)
-                } else {
-                    audiobook = OpenAccessAudiobook(JSON: JSON)
-                }
-            }
+        if let scheme = possibleScheme, scheme == "http://librarysimplified.org/terms/drm/scheme/FAE" {
+            let FindawayAudiobookClass = NSClassFromString("NYPLAEToolkit.FindawayAudiobook") as? Audiobook.Type
+            audiobook = FindawayAudiobookClass?.init(JSON: JSON)
         } else if let type = JSON["formatType"] as? String,
-            type == "audiobook-overdrive" {
-                audiobook = OverdriveAudiobook(JSON: JSON)
+                  type == "audiobook-overdrive" {
+            audiobook = OverdriveAudiobook(JSON: JSON)
         } else if let manifestContext = JSON["@context"] as? String, manifestContext == LCPAudiobook.manifestContext {
             audiobook = LCPAudiobook(JSON: JSON, decryptor: decryptor)
         } else {
             audiobook = OpenAccessAudiobook(JSON: JSON)
         }
+
         ATLog(.debug, "checkDrmAsync")
         audiobook?.checkDrmAsync()
         return audiobook
     }
-    
+
     /// Instatiate an audiobook object with JSON data containing spine elements of the book
     /// - Parameters:
     ///   - JSON: Audiobook and spine elements data

--- a/NYPLAudiobookToolkit/Core/Audiobook.swift
+++ b/NYPLAudiobookToolkit/Core/Audiobook.swift
@@ -57,11 +57,14 @@ import UIKit
         let drm = metadata?["encrypted"] as? [String: Any]
         let possibleScheme = drm?["scheme"] as? String
         let audiobook: Audiobook?
+        print("Breakpoint 1: JSON: \(JSON)")
         if let scheme = possibleScheme {
             switch scheme {
             case "http://librarysimplified.org/terms/drm/scheme/FAE":
                 let FindawayAudiobookClass = NSClassFromString("NYPLAEToolkit.FindawayAudiobook") as? Audiobook.Type
                 audiobook = FindawayAudiobookClass?.init(JSON: JSON)
+            case "http://readium.org/2014/01/lcp":
+                audiobook = LCPAudiobook(JSON: JSON, decryptor: decryptor)
             default:
                 audiobook = OpenAccessAudiobook(JSON: JSON)
             }

--- a/NYPLAudiobookToolkit/Core/Audiobook.swift
+++ b/NYPLAudiobookToolkit/Core/Audiobook.swift
@@ -57,7 +57,8 @@ import UIKit
         let drm = metadata?["encrypted"] as? [String: Any]
         let possibleScheme = drm?["scheme"] as? String
         let audiobook: Audiobook?
-    
+        print("Breakpoint 1: JSON: \(JSON)")
+
         if let scheme = possibleScheme {
             switch scheme {
             case "http://librarysimplified.org/terms/drm/scheme/FAE":

--- a/NYPLAudiobookToolkit/Core/Audiobook.swift
+++ b/NYPLAudiobookToolkit/Core/Audiobook.swift
@@ -57,9 +57,7 @@ import UIKit
         let drm = metadata?["encrypted"] as? [String: Any]
         let possibleScheme = drm?["scheme"] as? String
         let audiobook: Audiobook?
-        print("Breakpoint 1: JSON: \(JSON)")
-        return LCPAudiobook(JSON: JSON, decryptor: decryptor)
-
+    
         if let scheme = possibleScheme {
             switch scheme {
             case "http://librarysimplified.org/terms/drm/scheme/FAE":
@@ -68,7 +66,14 @@ import UIKit
             case "http://readium.org/2014/01/lcp":
                 audiobook = LCPAudiobook(JSON: JSON, decryptor: decryptor)
             default:
-                audiobook = OpenAccessAudiobook(JSON: JSON)
+                if let type = JSON["formatType"] as? String,
+                    type == "audiobook-overdrive" {
+                        audiobook = OverdriveAudiobook(JSON: JSON)
+                } else if let manifestContext = JSON["@context"] as? String, manifestContext == LCPAudiobook.manifestContext {
+                    audiobook = LCPAudiobook(JSON: JSON, decryptor: decryptor)
+                } else {
+                    audiobook = OpenAccessAudiobook(JSON: JSON)
+                }
             }
         } else if let type = JSON["formatType"] as? String,
             type == "audiobook-overdrive" {

--- a/NYPLAudiobookToolkit/Core/LCPAudiobook.swift
+++ b/NYPLAudiobookToolkit/Core/LCPAudiobook.swift
@@ -11,7 +11,7 @@ import Foundation
 @objc public class LCPAudiobook: NSObject, Audiobook {
     
     /// Readium @context parameter value for LCP audiobooks
-    static let manifestContext = "http://readium.org/webpub-manifest/context.jsonld"
+    static let manifestContext = "https://readium.org/webpub-manifest/context.jsonld"
     
     public var uniqueIdentifier: String
     


### PR DESCRIPTION
Update audiobook creation function to not default to OpenAccessAudiobook in the event that there is no matching scheme, until all other potential options are checked.