### PR TITLE
Display audiobook info on Apple Watch 

### DIFF
--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -152,7 +152,7 @@ var sharedLogHandler: LogHandler?
 
     @objc func timerDidTick1Second(_ timer: Timer) {
         self.timerDelegate?.audiobookManager(self, didUpdate: timer)
-//        guard self.audiobook.player.isLoaded else { return }
+        guard self.audiobook.player.isLoaded else { return }
         if let chapter = self.audiobook.player.currentChapterLocation {
             var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
             if let title = chapter.title {

--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -152,7 +152,7 @@ var sharedLogHandler: LogHandler?
 
     @objc func timerDidTick1Second(_ timer: Timer) {
         self.timerDelegate?.audiobookManager(self, didUpdate: timer)
-        guard self.audiobook.player.isLoaded else { return }
+//        guard self.audiobook.player.isLoaded else { return }
         if let chapter = self.audiobook.player.currentChapterLocation {
             var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
             if let title = chapter.title {

--- a/NYPLAudiobookToolkit/Core/OpenAccessAudiobook.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessAudiobook.swift
@@ -12,9 +12,9 @@ final class OpenAccessAudiobook: Audiobook {
             // Access to `drmData` is private and can only be modified by internal code
             return (drmData["status"] as? DrmStatus) ?? DrmStatus.succeeded
         }
-        set(newStatus) {
-            drmData["status"] = newStatus
-            player.isDrmOk = newStatus == DrmStatus.succeeded
+        set {
+            drmData["status"] = newValue
+            player.isDrmOk = (DrmStatus.succeeded == newValue)
         }
     }
     

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -15,8 +15,8 @@ class OpenAccessPlayer: NSObject, Player {
     }
     
     var isDrmOk: Bool {
-        didSet(oldValue) {
-            if !oldValue {
+        didSet {
+            if !isDrmOk {
                 pause()
                 notifyDelegatesOfPlaybackFailureFor(chapter: self.chapterAtCurrentCursor, NSError(domain: errorDomain, code: OpenAccessPlayerError.drmExpired.rawValue, userInfo: nil))
                 unload()


### PR DESCRIPTION
This fixes empty audiobook title and track title on Apple Watch and iOS player widget.

In certain cases, when license check was not performed, the app wan't setting media player title and subtitle property.

[Ticket](https://www.notion.so/lyrasis/Display-Audiobook-information-on-Apple-Watch-e9fc35aaae8d48408d4c0cdf528e81e0).