### PR TITLE
Fix/audiobook not persisting location

### DIFF
--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -216,8 +216,8 @@ class OpenAccessPlayer: NSObject, Player {
     private func seekWithinCurrentItem(newOffset: TimeInterval)
     {
         guard let currentItem = self.avQueuePlayer.currentItem else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                seekWithinCurrentItem(newOffset: newOffset)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.seekWithinCurrentItem(newOffset: newOffset)
             }
 
             ATLog(.error, "No current AVPlayerItem in AVQueuePlayer to seek with.")

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -216,7 +216,7 @@ class OpenAccessPlayer: NSObject, Player {
     private func seekWithinCurrentItem(newOffset: TimeInterval)
     {
         guard let currentItem = self.avQueuePlayer.currentItem else {
-            DispatchQueue.main.asyncAfter(deadline: .now + 1.0) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                 seekWithinCurrentItem(newOffset: newOffset)
             }
 

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -216,6 +216,10 @@ class OpenAccessPlayer: NSObject, Player {
     private func seekWithinCurrentItem(newOffset: TimeInterval)
     {
         guard let currentItem = self.avQueuePlayer.currentItem else {
+            DispatchQueue.main.asyncAfter(deadline: .now + 1.0) {
+                seekWithinCurrentItem(newOffset: newOffset)
+            }
+
             ATLog(.error, "No current AVPlayerItem in AVQueuePlayer to seek with.")
             return
         }

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -211,18 +211,27 @@ class OpenAccessPlayer: NSObject, Player {
         self.playAtLocation(location)
         self.pause()
     }
+    
+    private var retryCount = 0
 
     /// Moving within the current AVPlayerItem.
     private func seekWithinCurrentItem(newOffset: TimeInterval)
     {
         guard let currentItem = self.avQueuePlayer.currentItem else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard retryCount <= 2 else {
+                ATLog(.error, "No current AVPlayerItem in AVQueuePlayer to seek with.")
+                return
+            }
+
+            /// Attempts to seek on the current AVPlayerItem prior to initialization fail
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.retryCount += 1
                 self?.seekWithinCurrentItem(newOffset: newOffset)
             }
 
-            ATLog(.error, "No current AVPlayerItem in AVQueuePlayer to seek with.")
             return
         }
+
         if self.avQueuePlayer.currentItem?.status != .readyToPlay {
             ATLog(.debug, "Item not ready to play. Queueing seek operation.")
             self.queuedSeekOffset = newOffset


### PR DESCRIPTION
Implements a delayed retry to ensure that the AVPlayerItem has been initialized prior to attempting to update the location.

Treats: https://www.notion.so/lyrasis/Audiobooks-not-saving-last-read-place-aa7337fbd8824813acd15104953e532e