### PR TITLE
Queue seek offset before checking currentItem

### DIFF
--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -230,17 +230,17 @@ class OpenAccessPlayer: NSObject, Player {
     /// Moving within the current AVPlayerItem.
     private func seekWithinCurrentItem(newOffset: TimeInterval)
     {
-        guard let currentItem = self.avQueuePlayer.currentItem else {
-                ATLog(.error, "No current AVPlayerItem in AVQueuePlayer to seek with.")
-                return
-        }
-
         if self.avQueuePlayer.currentItem?.status != .readyToPlay {
             ATLog(.debug, "Item not ready to play. Queueing seek operation.")
             self.queuedSeekOffset = newOffset
             return
         }
-    
+        
+        guard let currentItem = self.avQueuePlayer.currentItem else {
+            ATLog(.error, "No current AVPlayerItem in AVQueuePlayer to seek with.")
+            return
+        }
+        
         currentItem.seek(to: CMTimeMakeWithSeconds(Float64(newOffset), preferredTimescale: Int32(1))) { finished in
             if finished {
                 ATLog(.debug, "Seek operation finished.")


### PR DESCRIPTION
This fixes timecode sync for audiobooks ([Ticket](https://www.notion.so/lyrasis/iOS-The-timecode-is-not-sync-after-reloading-the-app-or-returning-to-the-catalog-a7b66585ea24419ca0ec7afa6db67804)).

The problem was when `currentItem` is nil, i.e., the player is not ready, `seekWithinCurrentItem` was returning *before* actually saving offset position in `queuedSeekOffset`. The player tried to play from `queuedSeekOffset` once it was ready, and it was starting from the beginning of the track.