### PR TITLE
Ensure alerts are not presented from the background thread

### DIFF
--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -555,7 +555,9 @@ let SkipTimeInterval: Double = 15
         }
         alertController.addAction(alertAction)
 
-        self.present(alertController, animated: true)
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true)
+        }
 
         let bookID = self.audiobookManager.audiobook.uniqueIdentifier
         let logString = "\(#file): Player reported an error. Audiobook: \(bookID)"


### PR DESCRIPTION
https://www.notion.so/lyrasis/iOS-The-app-crashes-after-choosing-the-not-downloaded-chapter-in-TOC-in-Biblioboard-and-Palace-Mark-2cdb0d6ca9f84127bf64e8a048369ac8