### PR TITLE
Ensure loading indicator is always started and stopped from the main thread.

### DIFF
--- a/NYPLAudiobookToolkit/UI/BufferActivityIndicator.swift
+++ b/NYPLAudiobookToolkit/UI/BufferActivityIndicator.swift
@@ -9,8 +9,10 @@ class BufferActivityIndicatorView: UIActivityIndicatorView {
     private let debounceTimeInterval = 1.0
 
     override func startAnimating() {
-        super.startAnimating()
-
+        DispatchQueue.main.async {
+            super.startAnimating()
+        }
+        
         // Announce a "buffer" to VoiceOver with sufficient debounce...
         if debounceTimer == nil {
             debounceTimer = Timer.scheduledTimer(timeInterval: debounceTimeInterval,
@@ -22,8 +24,9 @@ class BufferActivityIndicatorView: UIActivityIndicatorView {
     }
 
     override func stopAnimating() {
-        super.stopAnimating()
-
+        DispatchQueue.main.async {
+            super.stopAnimating()
+        }
         debounceTimer?.invalidate()
         debounceTimer = nil
     }


### PR DESCRIPTION
https://www.notion.so/lyrasis/There-is-no-audiobook-position-sync-between-iPhone-SE-2020-iOS-15-2-and-other-devices-18685a19939646f0a9929aa7eb62a3b1

This line appears to be causing a non-fatal crash that may be causing the loading screen dismissal to fail on some devices.