### PR TITLE
Set Transifex to previous version

### DIFF
--- a/NYPLAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/NYPLAudiobookToolkit.xcodeproj/project.pbxproj
@@ -81,8 +81,8 @@
 		E549653327FBEAC400913BD6 /* toc_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E549653227FBEAC400913BD6 /* toc_manifest.json */; };
 		E549653527FBEB5100913BD6 /* non_toc_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E549653427FBEB5100913BD6 /* non_toc_manifest.json */; };
 		E549653727FCC52E00913BD6 /* AudiobookTOCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E549653627FCC52E00913BD6 /* AudiobookTOCTests.swift */; };
-		E59FCEC929425F81004FD730 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59FCEC829425F81004FD730 /* Strings.swift */; };
 		E59FCE9A29423E73004FD730 /* PureLayout in Frameworks */ = {isa = PBXBuildFile; productRef = E59FCE9929423E73004FD730 /* PureLayout */; };
+		E59FCEC929425F81004FD730 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59FCEC829425F81004FD730 /* Strings.swift */; };
 		E5A018BF2936887E003F6D01 /* alice_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E5A018BE2936887E003F6D01 /* alice_manifest.json */; };
 		E5A018C229368BC2003F6D01 /* the_martian_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E5A018C029368B17003F6D01 /* the_martian_manifest.json */; };
 		E5A7C3A82943A8920083BE1F /* Transifex in Frameworks */ = {isa = PBXBuildFile; productRef = E5A7C3A72943A8920083BE1F /* Transifex */; };
@@ -957,25 +957,22 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/transifex/transifex-swift/";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.0.0;
+				kind = exactVersion;
+				version = 1.0.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		E5A7C3A72943A8920083BE1F /* Transifex */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E5A7C3A62943A8920083BE1F /* XCRemoteSwiftPackageReference "transifex-swift" */;
-			productName = Transifex;
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		E59FCE9929423E73004FD730 /* PureLayout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E56EE121293FCFBD00D0E915 /* XCRemoteSwiftPackageReference "PureLayout" */;
 			productName = PureLayout;
+		};
+		E5A7C3A72943A8920083BE1F /* Transifex */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5A7C3A62943A8920083BE1F /* XCRemoteSwiftPackageReference "transifex-swift" */;
+			productName = Transifex;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/NYPLAudiobookToolkit/UI/AudiobookTrackTableViewCell.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookTrackTableViewCell.swift
@@ -23,7 +23,7 @@ class AudiobookTrackTableViewCell: UITableViewCell {
             labelAlpha = 0.4
         } else if progress > 0 && progress < 1  {
             let percentage = HumanReadablePercentage(percentage: progress).value
-            let labelFormat = Strings.Generic.downloading
+            let labelFormat = Strings.Generic.downloadingFormatted
             
             detailLabel = String(format: labelFormat, percentage)
             labelAlpha = 0.4

--- a/NYPLAudiobookToolkit/Utils/Strings.swift
+++ b/NYPLAudiobookToolkit/Utils/Strings.swift
@@ -45,7 +45,8 @@ struct Strings {
     }
     
     struct Generic {
-        static let downloading = NSLocalizedString("Downloading: %@%%", value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
+        static let downloading = NSLocalizedString("Downloading:", value: "Downloading:", comment: "")
+        static let downloadingFormatted = NSLocalizedString("Downloading: %@%%", value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
         static let loading = NSLocalizedString("Downloading: %@%%", value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
         static let pause = NSLocalizedString("Pause", value: "Pause", comment: "Pause")
         static let play = NSLocalizedString("Play", value: "Play", comment: "Play")


### PR DESCRIPTION
The latest version of Transifex is failing to build in the CI pipeline. The issue may be related to Xcode 13.2. We can test bumping Transifex when the server Xcode version is updated to 14.0.

Also includes a minor change to update an incorrectly pointed string.