### PR TITLE
Resolves audiobook skipping issues

### DIFF
--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -161,9 +161,7 @@ class OpenAccessPlayer: NSObject, Player {
         }
 
         self.playAtLocation(destination)
-        let playhead = move(cursor: self.cursor, to: destination)
-
-        completion?(playhead.location)
+        completion?(destination)
     }
 
     /// New Location's playhead offset could be oustide the bounds of audio, so

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -501,10 +501,8 @@ let SkipTimeInterval: Double = 15
 
     func middleTextFor(chapter: ChapterLocation) -> String {
         let defaultTitleFormat = DisplayStrings.trackAt
-        let middleTextFormat = DisplayStrings.fileNumber
         let indexString = oneBasedSpineIndex() ?? "--"
-        let title = chapter.title ?? String(format: defaultTitleFormat, indexString)
-        return String(format: middleTextFormat, title, indexString, self.audiobookManager.audiobook.spine.count)
+        return chapter.title ?? String(format: defaultTitleFormat, indexString)
     }
 
     func playbackSpeedTextFor(speedText: String) -> String {

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -466,7 +466,7 @@ let SkipTimeInterval: Double = 15
         }
 
         guard currentLocation.timeRemaining >= 0 else {
-            (self.audiobookManager.audiobook.player as? OpenAccessPlayer)?.currentPlayerItemEnded()
+            (self.audiobookManager.audiobook.player as? LCPPlayer)?.currentPlayerItemEnded()
             return
         }
     }

--- a/NYPLAudiobookToolkit/UI/AudiobookTrackTableViewCell.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookTrackTableViewCell.swift
@@ -23,7 +23,7 @@ class AudiobookTrackTableViewCell: UITableViewCell {
             labelAlpha = 0.4
         } else if progress > 0 && progress < 1  {
             let percentage = HumanReadablePercentage(percentage: progress).value
-            let labelFormat = Strings.Generic.downloading
+            let labelFormat = Strings.Generic.downloadingFormatted
             
             detailLabel = String(format: labelFormat, percentage)
             labelAlpha = 0.4

--- a/NYPLAudiobookToolkit/UI/PlaybackControlView.swift
+++ b/NYPLAudiobookToolkit/UI/PlaybackControlView.swift
@@ -166,10 +166,12 @@ final class PlaybackControlView: UIView {
     }
 
     @objc public func skipBackButtonWasTapped(_ sender: Any) {
+        self.skipBackView.disable(for: 1.0)
         self.delegate?.playbackControlViewSkipBackButtonWasTapped(self)
     }
 
     @objc public func skipForwardButtonWasTapped(_ sender: Any) {
+        self.skipForwardView.disable(for: 1.0)
         self.delegate?.playbackControlViewSkipForwardButtonWasTapped(self)
     }
 

--- a/NYPLAudiobookToolkit/UI/TextWithImageView.swift
+++ b/NYPLAudiobookToolkit/UI/TextWithImageView.swift
@@ -81,4 +81,17 @@ class TextOverImageView: UIControl {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    func disable(for seconds: Double) {
+        self.toggleInteractivity()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+            self.toggleInteractivity()
+        }
+    }
+
+    private func toggleInteractivity() {
+        self.isEnabled.toggle()
+        self.layer.opacity = self.isEnabled ? 1.0 : 0.25
+    }
 }

--- a/NYPLAudiobookToolkit/Utils/Strings.swift
+++ b/NYPLAudiobookToolkit/Utils/Strings.swift
@@ -45,7 +45,8 @@ struct Strings {
     }
     
     struct Generic {
-        static let downloading = NSLocalizedString("Downloading: %@%%", value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
+        static let downloading = NSLocalizedString("Downloading:", value: "Downloading:", comment: "")
+        static let downloadingFormatted = NSLocalizedString("Downloading: %@%%", value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
         static let loading = NSLocalizedString("Downloading: %@%%", value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
         static let pause = NSLocalizedString("Pause", value: "Pause", comment: "Pause")
         static let play = NSLocalizedString("Play", value: "Play", comment: "Play")


### PR DESCRIPTION
https://www.notion.so/lyrasis/Skipping-backwards-past-a-chapter-boundary-takes-you-to-the-wrong-chapter-4f56159b0a744141adabfa1b72bee4fd

- Disables skip button and adds a delay to prevent excessive chapter movement on rapid successive skips
- Removes (file %@ of %@) from `AudiobookViewController`
- minor copy change