### PR TITLE
Prevent skipping when player is not ready

### DIFF
--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -102,12 +102,12 @@ private var waitingForPlayer: Bool = false
                 }
                 return .success
         }, skipForwardHandler: { (_) -> MPRemoteCommandHandlerStatus in
-            guard !waitingForPlayer else { return .success }
+            guard !waitingForPlayer || audiobook.player.queuesEvents else { return .success }
             waitingForPlayer = true
             audiobook.player.skipPlayhead(SkipTimeInterval, completion: nil)
             return .success
         }, skipBackHandler: { (_) -> MPRemoteCommandHandlerStatus in
-            guard !waitingForPlayer else { return .success }
+            guard !waitingForPlayer || audiobook.player.queuesEvents else { return .success }
             waitingForPlayer = true
             audiobook.player.skipPlayhead(-SkipTimeInterval, completion: nil)
             return .success

--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -32,6 +32,8 @@ import AVFoundation
 /// above a certain log level in a release build.
 var sharedLogHandler: LogHandler?
 
+private var waitingForPlayer: Bool = false
+
 /// AudiobookManager is the main class for bringing Audiobook Playback to clients.
 /// It is intended to be used by the host app to initiate downloads,
 /// access the player, and manage the filesystem.
@@ -53,8 +55,6 @@ var sharedLogHandler: LogHandler?
     static func setLogHandler(_ handler: @escaping LogHandler)
     var playbackCompletionHandler: (() -> ())? { get set }
 }
-
-private var waitingForPlayer: Bool = false
 
 /// Implementation of the AudiobookManager intended for use by clients. Also intended
 /// to be used by the AudibookDetailViewController to respond to UI events.

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -3,7 +3,7 @@ import AVFoundation
 let AudioInterruptionNotification =  AVAudioSession.interruptionNotification
 
 class OpenAccessPlayer: NSObject, Player {
-
+    var queuesEvents: Bool = false
     var taskCompletion: Completion? = nil
 
     var errorDomain: String {

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -45,7 +45,8 @@ import Foundation
     typealias Completion = (Error?) -> Void
 
     var isPlaying: Bool { get }
-    
+    // Player maintains an internal queue
+    var queuesEvents: Bool { get }
     // When set, should lock down playback
     var isDrmOk: Bool { get set }
     

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -402,8 +402,7 @@ private func findPreviousChapter(cursor: Cursor<SpineElement>, timeIntoPreviousC
     
     let destinationChapter = chapterAt(cursor: newCursor)
     let playheadOffset = destinationChapter.duration - timeIntoPreviousChapter
-    
-    guard playheadOffset > 0 else {
+    guard playheadOffset > 0 || destinationChapter.number == 0 else {
         return findPreviousChapter(cursor: newCursor, timeIntoPreviousChapter: abs(playheadOffset))
     }
 

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -201,7 +201,7 @@ extension Player {
         try container.encode(audiobookID, forKey: .audiobookID)
     }
 
-    public init(number: UInt, part: UInt, duration: TimeInterval, startOffset: TimeInterval, playheadOffset: TimeInterval, title: String?, audiobookID: String) {
+    public init(number: UInt, part: UInt, duration: TimeInterval, startOffset: TimeInterval?, playheadOffset: TimeInterval, title: String?, audiobookID: String) {
         self.audiobookID = audiobookID
         self.number = number
         self.part = part
@@ -217,7 +217,7 @@ extension Player {
             number: self.number,
             part: self.part,
             duration: self.duration,
-            startOffset: self.chapterOffset ?? 0,
+            startOffset: self.chapterOffset,
             playheadOffset: offset,
             title: self.title,
             audiobookID: self.audiobookID
@@ -400,7 +400,7 @@ private func findPreviousChapter(cursor: Cursor<SpineElement>, timeIntoPreviousC
     guard let newCursor = cursor.prev() else { return nil }
     
     let destinationChapter = chapterAt(cursor: newCursor)
-    let playheadOffset = destinationChapter.duration - timeIntoPreviousChapter + (destinationChapter.chapterOffset ?? destinationChapter.playheadOffset)
+    let playheadOffset = destinationChapter.duration - timeIntoPreviousChapter
     
     guard playheadOffset > 0 else {
         return findPreviousChapter(cursor: newCursor, timeIntoPreviousChapter: abs(playheadOffset))

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -372,7 +372,7 @@ private func findNextChapter(cursor: Cursor<SpineElement>, timeIntoNextChapter: 
         return findNextChapter(cursor: newCursor, timeIntoNextChapter: remainingTimeIntoNextChapter)
     }
 
-    return (newCursor, destinationChapter.update(playheadOffset: destinationChapter.playheadOffset + timeIntoNextChapter))
+    return (newCursor, destinationChapter.update(playheadOffset: (destinationChapter.chapterOffset ?? destinationChapter.playheadOffset) + timeIntoNextChapter))
 }
 
 private func attemptToMove(cursor: Cursor<SpineElement>, backTo location: ChapterLocation) -> Playhead?  {
@@ -400,7 +400,7 @@ private func findPreviousChapter(cursor: Cursor<SpineElement>, timeIntoPreviousC
     guard let newCursor = cursor.prev() else { return nil }
     
     let destinationChapter = chapterAt(cursor: newCursor)
-    let playheadOffset = destinationChapter.duration - timeIntoPreviousChapter
+    let playheadOffset = destinationChapter.duration - timeIntoPreviousChapter + (destinationChapter.chapterOffset ?? destinationChapter.playheadOffset)
     
     guard playheadOffset > 0 else {
         return findPreviousChapter(cursor: newCursor, timeIntoPreviousChapter: abs(playheadOffset))

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -312,7 +312,7 @@ public func move(cursor: Cursor<SpineElement>, to destination: ChapterLocation) 
 ///   - skipTime: The requested skip time interval
 /// - Returns: The new Playhead Offset location that should be set
 public func adjustedPlayheadOffset(currentPlayheadOffset currentOffset: TimeInterval,
-                                   actualPlayheadOffset actualOffset: TimeInterval? = 0,
+                                   actualPlayheadOffset actualOffset: TimeInterval? = nil,
                                    currentChapterDuration chapterDuration: TimeInterval,
                                    requestedSkipDuration skipTime: TimeInterval) -> TimeInterval {
     let requestedPlayheadOffset = currentOffset + skipTime

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -595,7 +595,7 @@ extension AudiobookPlayerViewController: AudiobookManagerTimerDelegate {
 
 extension AudiobookPlayerViewController: PlaybackControlViewDelegate {
     func playbackControlViewSkipBackButtonWasTapped(_ playbackControlView: PlaybackControlView) {
-        guard !waitingForPlayer else { return }
+        guard !waitingForPlayer || self.audiobookManager.audiobook.player.queuesEvents else { return }
 
         self.waitingForPlayer = true
         if self.audiobookManager.audiobook.player.isPlaying {
@@ -612,7 +612,7 @@ extension AudiobookPlayerViewController: PlaybackControlViewDelegate {
     }
     
     func playbackControlViewSkipForwardButtonWasTapped(_ playbackControlView: PlaybackControlView) {
-        guard !waitingForPlayer else { return }
+        guard !waitingForPlayer || self.audiobookManager.audiobook.player.queuesEvents else { return }
 
         self.waitingForPlayer = true
         if self.audiobookManager.audiobook.player.isPlaying {

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -595,6 +595,7 @@ extension AudiobookPlayerViewController: AudiobookManagerTimerDelegate {
 
 extension AudiobookPlayerViewController: PlaybackControlViewDelegate {
     func playbackControlViewSkipBackButtonWasTapped(_ playbackControlView: PlaybackControlView) {
+        guard !waitingForPlayer else { return }
 
         self.waitingForPlayer = true
         if self.audiobookManager.audiobook.player.isPlaying {
@@ -611,6 +612,7 @@ extension AudiobookPlayerViewController: PlaybackControlViewDelegate {
     }
     
     func playbackControlViewSkipForwardButtonWasTapped(_ playbackControlView: PlaybackControlView) {
+        guard !waitingForPlayer else { return }
 
         self.waitingForPlayer = true
         if self.audiobookManager.audiobook.player.isPlaying {

--- a/NYPLAudiobookToolkit/UI/PlaybackControlView.swift
+++ b/NYPLAudiobookToolkit/UI/PlaybackControlView.swift
@@ -166,12 +166,10 @@ final class PlaybackControlView: UIView {
     }
 
     @objc public func skipBackButtonWasTapped(_ sender: Any) {
-        self.skipBackView.disable(for: 1.0)
         self.delegate?.playbackControlViewSkipBackButtonWasTapped(self)
     }
 
     @objc public func skipForwardButtonWasTapped(_ sender: Any) {
-        self.skipForwardView.disable(for: 1.0)
         self.delegate?.playbackControlViewSkipForwardButtonWasTapped(self)
     }
 

--- a/NYPLAudiobookToolkit/UI/TextWithImageView.swift
+++ b/NYPLAudiobookToolkit/UI/TextWithImageView.swift
@@ -81,17 +81,4 @@ class TextOverImageView: UIControl {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    func disable(for seconds: Double) {
-        self.toggleInteractivity()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
-            self.toggleInteractivity()
-        }
-    }
-
-    private func toggleInteractivity() {
-        self.isEnabled.toggle()
-        self.layer.opacity = self.isEnabled ? 1.0 : 0.25
-    }
 }


### PR DESCRIPTION
- Prevents successive skip calls while player is processing previous skips. 
- Removes less desirable UI blocking delay

Dependency:
https://github.com/ThePalaceProject/ios-drm-audioengine/pull/16