### PR TITLE
PP-87 Book download fails after locking screen for roughly 10 seconds

### DIFF
--- a/NYPLAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -158,7 +158,8 @@ final class OpenAccessDownloadTask: DownloadTask {
 
     private func downloadAsset(fromRemoteURL remoteURL: URL, toLocalDirectory finalURL: URL)
     {
-        let config = URLSessionConfiguration.ephemeral
+        let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "").appending(".openAccessBackgroundIdentifier")
+        let config = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
         let delegate = OpenAccessDownloadTaskURLSessionDelegate(downloadTask: self,
                                                                 delegate: self.delegate,
                                                                 finalDirectory: finalURL)

--- a/NYPLAudiobookToolkit/Network/OverdriveDownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/OverdriveDownloadTask.swift
@@ -90,7 +90,8 @@ final class OverdriveDownloadTask: DownloadTask {
     
     private func downloadAsset(fromRemoteURL remoteURL: URL, toLocalDirectory finalURL: URL)
     {
-        let config = URLSessionConfiguration.ephemeral
+        let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "").appending(".overdriveBackgroundIdentifier")
+        let config = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
         let delegate = OverdriveDownloadTaskURLSessionDelegate(downloadTask: self,
                                                                delegate: self.delegate,
                                                                finalDirectory: finalURL)


### PR DESCRIPTION
This PR fixes failing downloads of large audio files when the app goes into background mode ([Ticket](https://ebce-lyrasis.atlassian.net/browse/PP-87)).