### PR TITLE
PP-555 Fix chapter title layout

### DIFF
--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -57,16 +57,17 @@ struct AudiobookPlayerView: View {
                             }
                             .padding(.horizontal)
                             
-                            ZStack {
-                                HStack {
-                                    Text("\(playheadOffsetText)")
-                                        .font(.caption)
-                                    Spacer()
-                                    Text("\(timeLeftText)")
-                                        .font(.caption)
-                                }
+                            HStack(alignment: .firstTextBaseline) {
+                                Text("\(playheadOffsetText)")
+                                    .font(.caption)
+                                Spacer()
                                 Text(chapterTitle)
                                     .font(.headline)
+                                    .multilineTextAlignment(.center)
+                                    .lineLimit(2)
+                                Spacer()
+                                Text("\(timeLeftText)")
+                                    .font(.caption)
                             }
                             .padding(.horizontal)
                         }


### PR DESCRIPTION
Fixes chapter title layout - long chapter titles used to cover time labels [PP-555](https://ebce-lyrasis.atlassian.net/browse/PP-555)

[PP-555]: https://ebce-lyrasis.atlassian.net/browse/PP-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ