### PR TITLE
Display cover image on lock screen

### DIFF
--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 import Combine
-
+import MediaPlayer
 
 class AudiobookPlaybackModel: ObservableObject, PlayerDelegate, AudiobookManagerTimerDelegate, AudiobookNetworkServiceDelegate {
 
@@ -213,4 +213,33 @@ class AudiobookPlaybackModel: ObservableObject, PlayerDelegate, AudiobookManager
         spineErrors.removeValue(forKey: spineElement.key)
     }
     
+    // MARK: - Media Player
+    
+    func updateCoverImage(_ image: UIImage?) {
+        coverImage = image
+        updateLockScreenCoverArtwork(image: image)
+    }
+    
+    private func updateLockScreenCoverArtwork(image: UIImage?) {
+        if let image = image {
+            let itemArtwork = MPMediaItemArtwork.init(boundsSize: image.size) { requestedSize -> UIImage in
+                // Scale aspect fit to size requested by system
+                let rect = AVMakeRect(aspectRatio: image.size, insideRect: CGRect(origin: .zero, size: requestedSize))
+                UIGraphicsBeginImageContextWithOptions(rect.size, true, 0.0)
+                image.draw(in: CGRect(origin: .zero, size: rect.size))
+                let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+                UIGraphicsEndImageContext()
+                if let scaledImage = scaledImage {
+                    return scaledImage
+                } else {
+                    return image
+                }
+            }
+            
+            var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+            info[MPMediaItemPropertyArtwork] = itemArtwork
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        }
+    }
+
 }

--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -28,7 +28,7 @@ struct AudiobookPlayerView: View {
     }
     
     public func updateImage(_ image: UIImage) {
-        playbackModel.coverImage = image
+        playbackModel.updateCoverImage(image)
     }
     
     public func unload() {


### PR DESCRIPTION
Updates Media Player cover when PalaceAudiobookPlayer receives an audiobook cover - the feature was lost in UIKit → SwiftUI conversion [PP-587](https://ebce-lyrasis.atlassian.net/browse/PP-587).

[PP-587]: https://ebce-lyrasis.atlassian.net/browse/PP-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ