### PR TITLE
Turn deleteLocalContent into a class method (PP-1024)

### DIFF
--- a/PalaceAudiobookToolkit/Core/FindawayAudiobook.swift
+++ b/PalaceAudiobookToolkit/Core/FindawayAudiobook.swift
@@ -11,16 +11,22 @@ import AudioEngine
 
 public final class FindawayAudiobook: Audiobook {
     public required init?(manifest: Manifest, bookIdentifier: String, decryptor: DRMDecryptor? = nil, token: String? = nil) {
-        guard let fulfillmentId = manifest.metadata?.drmInformation?.fulfillmentId else {
+        guard let fulfillmentId = type(of: self).getFulfillmentId(from: manifest) else {
             return nil
         }
         
         super.init(manifest: manifest, bookIdentifier: fulfillmentId, decryptor: decryptor, token: token)
         self.uniqueId = fulfillmentId
     }
-    
-    public override func deleteLocalContent(completion: @escaping (Bool, Error?) -> Void) {
-        FAEAudioEngine.shared()?.downloadEngine?.delete(forAudiobookID: self.uniqueId)
-        completion(true, nil)
+
+    private class func getFulfillmentId(from manifest: Manifest) -> String? {
+        return manifest.metadata?.drmInformation?.fulfillmentId
+    }
+
+    public override class func deleteLocalContent(manifest: Manifest, bookIdentifier: String, token: String? = nil) {
+        guard let fulfillmentId = getFulfillmentId(from: manifest) else {
+            return
+        }
+        FAEAudioEngine.shared()?.downloadEngine?.delete(forAudiobookID: fulfillmentId)
     }
 }


### PR DESCRIPTION
Turn `deleteLocalContent` into a class method, so that we can call it without instantiating an `Audiobook`, since initializing an audiobook creates a player instance, which we don't necessarily want to do when just trying to delete audiobook content. 

This change was made for PP-1024, to fix a bug that wasn't deleting content when it is returned on the device.