### PR TITLE
Stop LCPStreamingPlayer muting on mid-playback buffering

### DIFF
--- a/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
@@ -36,6 +36,7 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
   private var suppressAudibleUntilPlaying = false
   private var lastStartedItemKey: String?
   private var isSeekingWithinSameTrack = false
+  private var loadTimeoutWorkItem: DispatchWorkItem?
 
   override var currentOffset: Double {
     guard let currentTrackPosition, let currentChapter else {
@@ -188,20 +189,20 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
       suppressAudibleUntilPlaying = true
       avQueuePlayer.isMuted = true
       lastStartedItemKey = nil
-      
-      DispatchQueue.main.asyncAfter(deadline: .now() + 30.0) { [weak self] in
-        if let self = self, !self.isLoaded {
-          ATLog(.warn, "LCPStreamingPlayer: Publication loading taking longer than expected, attempting fallback")
-          if streamingProvider?.getPublication() != nil || !avQueuePlayer.items().isEmpty {
-            ATLog(.debug, "🎵 [LCPStreamingPlayer] Fallback: Publication or items available, proceeding")
-            isLoaded = true
-            suppressAudibleUntilPlaying = false
-            avQueuePlayer.isMuted = false
-          } else {
-            ATLog(.error, "🎵 [LCPStreamingPlayer] Critical timeout: No publication or items available")
-          }
-        }
+
+      // Cancel any prior fallback from an earlier play(at:) so stale timers don't
+      // fire after the queue has advanced past the startup window. Without this,
+      // rapid re-presentations stack multiple timers that all log at once.
+      loadTimeoutWorkItem?.cancel()
+      let workItem = DispatchWorkItem { [weak self] in
+        guard let self = self, !self.isLoaded else { return }
+        ATLog(.warn, "LCPStreamingPlayer: Publication loading timeout — forcing unmute so audio is not stuck")
+        self.isLoaded = true
+        self.suppressAudibleUntilPlaying = false
+        self.avQueuePlayer.isMuted = false
       }
+      loadTimeoutWorkItem = workItem
+      DispatchQueue.main.asyncAfter(deadline: .now() + 30.0, execute: workItem)
     }
 
     if !needsRebuild {
@@ -564,6 +565,8 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
         switch player.timeControlStatus {
         case .playing:
           self.isLoaded = true
+          loadTimeoutWorkItem?.cancel()
+          loadTimeoutWorkItem = nil
           if suppressAudibleUntilPlaying {
             avQueuePlayer.isMuted = false
             suppressAudibleUntilPlaying = false
@@ -580,7 +583,11 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
             }
           }
         case .waitingToPlayAtSpecifiedRate:
-          if !isSeekingWithinSameTrack {
+          // AVPlayer enters this state for ordinary mid-playback buffering, not just
+          // initial load. Only treat it as "not loaded" while we've never confirmed
+          // `.playing` for the current play(at:) call — otherwise every LCP decrypt
+          // gap re-mutes the player and leaves the user on a silent spinner.
+          if lastStartedItemKey == nil, !isSeekingWithinSameTrack {
             self.isLoaded = false
             if !self.avQueuePlayer.isMuted {
               avQueuePlayer.isMuted = true


### PR DESCRIPTION
## Summary
- AVPlayer enters `.waitingToPlayAtSpecifiedRate` every time it buffers (including mid-playback decrypt gaps), not just initial load. The KVO observer was re-muting the queue and resetting `isLoaded=false` on every such event, which left the user on a muted loading spinner while LCP inflated 20–40 MB chunks.
- Each `play(at:)` call scheduled a fresh 30s fallback `DispatchQueue.asyncAfter` without cancelling prior ones, so stale timers stacked up and spammed "Critical timeout: No publication or items available" even while playback was actively advancing.

## Changes
- `LCPStreamingPlayer.play(at:)` now tracks the 30s fallback as a cancellable `DispatchWorkItem` and cancels prior ones before scheduling a new one.
- The fallback unconditionally unmutes on timeout rather than logging "Critical timeout" and leaving the user silent. Cautious audio beats certain silence.
- `.waitingToPlayAtSpecifiedRate` only re-mutes while `lastStartedItemKey == nil` (i.e., initial load for this `play(at:)` call). Mid-playback buffering is now transparent.
- `.playing` cancels the pending `loadTimeoutWorkItem`.

## Observed behavior on device (iPhone 17 Pro Max, iOS 26.3.1)
Reproduced on staging with *Carl's Doomsday Scenario* and *The Gate of the Feral Gods* (both LCP, 600–778 MB). Before the fix: 4× "Critical timeout" log bursts per presentation, audio muted for 30+ seconds at a time, chapter timestamps still advancing silently in the background. After the fix: audio comes up on first `.playing` and stays up through subsequent buffer gaps.

## Test plan
- [ ] Open a downloaded LCP audiobook from My Books; confirm audio starts within a few seconds of tap.
- [ ] Scrub to a position deep in the book (e.g., chapter 3); confirm audio doesn't mute during the seek + decrypt burst.
- [ ] Navigate away from the player and back; confirm playback resumes without muted-spinner pauses.
- [ ] Exercise a non-LCP audiobook (Blackstone/BiblioBoard) to confirm no regression in OpenAccessPlayer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)