### PR TITLE
Surface LCP streaming load timeout + slider light-mode contrast

### DIFF
--- a/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
@@ -194,12 +194,26 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
       // fire after the queue has advanced past the startup window. Without this,
       // rapid re-presentations stack multiple timers that all log at once.
       loadTimeoutWorkItem?.cancel()
+      let timeoutPosition = position
+      let timeoutCompletion = completion
       let workItem = DispatchWorkItem { [weak self] in
         guard let self = self, !self.isLoaded else { return }
-        ATLog(.warn, "LCPStreamingPlayer: Publication loading timeout — forcing unmute so audio is not stuck")
+        ATLog(.warn, "LCPStreamingPlayer: Publication loading timeout — surfacing failure so caller can show an alert and release the open lock")
         self.isLoaded = true
         self.suppressAudibleUntilPlaying = false
         self.avQueuePlayer.isMuted = false
+
+        // Emit a playback failure so AudiobookManager → Palace surfaces the
+        // "Audiobook Unavailable" alert and the BookService open lock releases
+        // instead of latching. Without this, a stalled resource loader looks
+        // identical to a successful open from the UI's perspective.
+        let timeoutError = NSError(
+          domain: "LCPStreamingPlayer",
+          code: -1,
+          userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for LCP publication to load"]
+        )
+        self.playbackStatePublisher.send(.failed(timeoutPosition, timeoutError))
+        timeoutCompletion?(timeoutError)
       }
       loadTimeoutWorkItem = workItem
       DispatchQueue.main.asyncAfter(deadline: .now() + 30.0, execute: workItem)
@@ -247,6 +261,7 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
                 isLoaded = true
                 suppressAudibleUntilPlaying = false
                 avQueuePlayer.isMuted = false
+                self.loadTimeoutWorkItem?.cancel()
               }
             }
           } else {

--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -885,7 +885,7 @@ struct PlaybackSliderView: View {
       ZStack(alignment: .leading) {
         // Background track
         Capsule()
-          .fill(Color.white.opacity(0.2))
+          .fill(Color(.systemGray4))
           .frame(height: currentTrackHeight)
 
         // Progress fill


### PR DESCRIPTION
## Summary

- **LCPStreamingPlayer**: The 30s publication-load timeout was a silent unmute — it set `isLoaded = true` and cleared the muted state but never notified the caller. Callers' completion handlers never fired, and the playback state publisher never emitted a failure, so `AudiobookManager → AudiobookSessionManager` stayed in "loading" state and the UI showed no alert. Now the timeout emits `PlaybackState.failed(position, timeoutError)` AND calls the caller's completion with the same error, so both the UI (`AudiobookSessionManager.handlePlaybackFailed` → "Audiobook Unavailable" alert) and the caller's open lock (Palace's `BookService`) can react. The timeout work item is also canceled on successful seek to eliminate a small double-fire window where seek and timeout fire near the same time.
- **AudiobookPlayerView**: `PlaybackSliderView` background track was `Color.white.opacity(0.2)`, which is ~1:1 contrast in light mode (invisible against the light background). Changed to `Color(.systemGray4)`, which is adaptive and renders as a consistent light gray in both modes — dark-mode appearance is preserved, light-mode is now visible.

## Why this matters

Without the timeout failure signal, a stalled LCP publication fetch (e.g., network blip against `storage.googleapis.com`) is indistinguishable from a successful load to the UI. The user sees an "Open" button that does nothing, no alert, and a dedup lock in the parent app that latches forever so even retries are silently ignored. Downstream PR in `ios-core` depends on this commit.

## Test plan

- [x] Build: `xcodebuild -project Palace.xcodeproj -scheme Palace -destination 'platform=iOS Simulator,id=DF4A2A27-9888-429D-A749-2E157A049A37' build` passes cleanly with the submodule bumped to this commit.
- [ ] Manual: reproduce the network-fail scenario (airplane mode mid-LCP-fetch) and confirm the user sees the "Audiobook Unavailable" alert within 30s instead of a silent stuck player.
- [x] Visual: slider background is visible light gray in light mode and unchanged in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)