### PR TITLE
[3.0.1] Pin DateFormatter locale/calendar/timeZone in Manifest decoder

### DIFF
--- a/PalaceAudiobookToolkit/Player/Helpers/Models/Manifest.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Models/Manifest.swift
@@ -117,7 +117,15 @@ public struct Manifest: Codable {
         "yyyy-MM-dd"
       ]
 
+      // Apple TN2154 / QA1480: pin locale, calendar, and timeZone so fixed-format
+      // dates stay parseable when the user's iOS region uses a non-Gregorian calendar
+      // or non-Latin numerals.  Helpspot 17727 — RAILS user on iOS could not open any
+      // audiobook because the unconfigured DateFormatter rejected (or silently
+      // shifted) the manifest's `metadata.modified` value.
       let dateFormatter = DateFormatter()
+      dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+      dateFormatter.calendar = Calendar(identifier: .gregorian)
+      dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
       for dateFormat in dateFormats {
         dateFormatter.dateFormat = dateFormat

--- a/PalaceAudiobookToolkit/Player/Helpers/Models/Metadata.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Models/Metadata.swift
@@ -117,7 +117,13 @@ public extension Manifest {
       "yyyy-MM-dd"
     ]
 
+    // Pin locale/calendar/timeZone (Apple TN2154 / QA1480) — same fix as
+    // Manifest.customDecoder; without it this helper produces wrong dates on
+    // devices configured for non-Gregorian calendars.
     let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.calendar = Calendar(identifier: .gregorian)
+    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
     for format in dateFormats {
       dateFormatter.dateFormat = format
       if let date = dateFormatter.date(from: string) {


### PR DESCRIPTION
## Summary

Pin `Locale("en_US_POSIX") + Calendar(.gregorian) + TimeZone(secondsFromGMT: 0)` on the
two `DateFormatter` instances inside `Manifest.customDecoder()` and `Manifest.Metadata.date(from:)`.

## Why

Helpspot 17727 — every audiobook open failed for a RAILS eRead patron on iOS 3.0.0 with:
`dataCorrupted at metadata → modified — Cannot decode date string 2026-02-17T15:56:15+0000`.
The decoder used `DateFormatter()` without pinning locale/calendar/timeZone — Apple's
[TN2154](https://developer.apple.com/library/archive/qa/qa1480/_index.html) anti-pattern.
Without the pin, fixed-format date parsing depends on whichever device prefs `Locale.current`
and `Calendar.current` happen to expose at decode time.

### What's confirmed vs inferred

**Confirmed (reproduced on iOS 26.2 sim):** an unpinned formatter parses
`2026-02-17T15:56:15+0000` into wildly wrong instants under non-Gregorian device calendars
(Buddhist → 1483, Japanese → 4044, Islamic → 2587, Persian → 2647, Hebrew → −1735).

**Inferred:** the customer's exact `nil` outcome (which produces the `Cannot decode date
string` throw) was not reproduced in our test grid. It is plausible — Apple's QA1480 lists
several device-pref combinations that drive `DateFormatter.date(from:)` to nil — but we don't
have direct evidence of which one Jersey hit. Her StoreKit log shows `locale: en_US` (the App
Store storefront), but device-level Calendar / Number Format / 24-Hour Time settings are not
captured in any log we have.

**Why the fix still ships regardless:** every plausible root cause — calendar override, number
format override, 24-hour-time off, ICU bundle pressure, iOS version-specific Foundation
behavior — is solved by pinning locale/calendar/timeZone. The fix is the intersection of every
candidate, not a guess at one. The rest of the Palace codebase (palace-ios) already pins
`en_US_POSIX` in 10+ places for exactly this reason; this PR aligns the toolkit with that
convention.

## Surface
+14 lines, two files, zero behavior change for en_US Gregorian users.

## Test plan
- [x] iOS 26.2 simulator: 3 new XCTests in `PalaceTests/Audiobooks/ManifestDateDecodeRegressionTests.swift`
      (in palace-ios — toolkit can't compile its tests standalone without PalaceUIKit). Suite
      includes the customer's exact failing string + a diagnostic that fails if anyone removes
      the pin.
- [x] Existing audiobook test suites: 66 passed, 0 failed.
- [ ] Post-merge: query Crashlytics for residual `AudiobookOpenError 401 — Cannot decode date
      string` events. If they disappear, the locale anti-pattern was the root cause; if any
      remain, we need to chase memory / ICU / iOS-version-specific causes separately.

## Base

**Branched off `1926b614`** — the SHA `palace-ios/release/3.0.0` and PR #898's
`hotfix/3.0.1-saml-recoverable-auth` already pin. `main` is 1 commit ahead
(`a84d6935` — DownloadWatchdog teardown race #168) and that commit must NOT come
along for the 3.0.1 release. Reviewers should sanity-check that this PR's diff
against `main` is *only* the +14-line locale pin, nothing else.

## Companion

Sibling palace-ios PR (ThePalaceProject/ios-core#903) bumps the submodule pointer to this
branch's HEAD on `hotfix/3.0.1-saml-recoverable-auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)