### PR TITLE
PP-4156: Restore audiobook download indicator for all player types

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7B6C1BD0203F1CDA00EB791E /* AudiobookNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6C1BCF203F1CDA00EB791E /* AudiobookNetworkService.swift */; };
 		7B6C1BD420405C4D00EB791E /* CursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6C1BD320405C4D00EB791E /* CursorTests.swift */; };
 		7B78545B204DEE8500F6589B /* AudiobookNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */; };
+		PP41560001AAAA0001AAAA01 /* AudiobookPlaybackModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */; };
 		7B78545D204DEE9900F6589B /* DownloadTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */; };
 		7B7B370820211CE100030A1E /* OpenAccessDownloadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7B370720211CE100030A1E /* OpenAccessDownloadTask.swift */; };
 		7B8026A3206AB0AF00012808 /* HumanReadablePlaybackRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8026A2206AB0AF00012808 /* HumanReadablePlaybackRate.swift */; };
@@ -194,6 +195,7 @@
 		7B6C1BCF203F1CDA00EB791E /* AudiobookNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookNetworkService.swift; sourceTree = "<group>"; };
 		7B6C1BD320405C4D00EB791E /* CursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorTests.swift; sourceTree = "<group>"; };
 		7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookNetworkServiceTest.swift; sourceTree = "<group>"; };
+		PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookPlaybackModelTests.swift; sourceTree = "<group>"; };
 		7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadTaskMock.swift; sourceTree = "<group>"; };
 		7B7B370720211CE100030A1E /* OpenAccessDownloadTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAccessDownloadTask.swift; sourceTree = "<group>"; };
 		7B8026A2206AB0AF00012808 /* HumanReadablePlaybackRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HumanReadablePlaybackRate.swift; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				E549653127FBEAA900913BD6 /* TestResources */,
 				7B54419C200EA7C20047B6C6 /* Info.plist */,
 				7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */,
+				PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */,
 				7B6C1BD320405C4D00EB791E /* CursorTests.swift */,
 				8CD8A20E243E7A0D009DA4CC /* Data+BigEndianTest.swift */,
 				7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */,
@@ -904,6 +907,7 @@
 				7BBF4E002050856400700731 /* PlayerMock.swift in Sources */,
 				7BBF4DFE2050850A00700731 /* SleepTimerTests.swift in Sources */,
 				7B78545B204DEE8500F6589B /* AudiobookNetworkServiceTest.swift in Sources */,
+				PP41560001AAAA0001AAAA01 /* AudiobookPlaybackModelTests.swift in Sources */,
 				7B78545D204DEE9900F6589B /* DownloadTaskMock.swift in Sources */,
 				E5B05DAA2BA4DB4500686897 /* TableOfContentsTests.swift in Sources */,
 				8C3CDB042422AB060020FC0B /* JSONUtilsTest.swift in Sources */,

--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -163,8 +163,7 @@ public class AudiobookPlaybackModel: ObservableObject {
         }
         switch state {
         case let .overallDownloadProgress(overallProgress):
-          let isLCPStreaming = audiobookManager.audiobook.player is LCPStreamingPlayer
-          isDownloading = !isLCPStreaming && overallProgress < 1
+          isDownloading = AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: overallProgress)
           // Clamp to max-seen-so-far to prevent the progress bar from sliding backwards
           overallDownloadProgress = max(overallDownloadProgress, overallProgress)
         case let .positionUpdated(position):
@@ -532,5 +531,17 @@ public class AudiobookPlaybackModel: ObservableObject {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
       }
     }
+  }
+}
+
+// MARK: - PP-4156 download-indicator visibility rule
+public extension AudiobookPlaybackModel {
+  /// Whether the player's download-progress indicator should be visible for a given
+  /// overall download progress value. The rule is intentionally a function of progress
+  /// only — adding a player-type parameter (as a prior commit did) hid the indicator
+  /// for LCP audiobooks even while their tracks were still decrypting in the background.
+  /// PP-4156: PR introduced via git, see retrospective for full context.
+  static func shouldShowDownloadIndicator(forOverallProgress progress: Float) -> Bool {
+    progress < 1
   }
 }

--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -378,20 +378,23 @@ public struct AudiobookPlayerView: View {
 
   @ViewBuilder
   private func downloadProgressView(value: Float) -> some View {
+    // PP-4156: indicator uses semantic colors so it remains visible against the player's
+    // system-background (white in light mode, black in dark). Hard-coded white-on-white was
+    // invisible in light mode even when isDownloading was true.
     VStack(spacing: 6) {
       HStack(spacing: 8) {
         Image(systemName: "arrow.down.circle.fill")
           .font(.system(size: 12, weight: .medium))
-          .foregroundColor(.white.opacity(0.6))
+          .foregroundColor(.secondary)
 
         GeometryReader { geometry in
           ZStack(alignment: .leading) {
             Capsule()
-              .fill(Color.white.opacity(0.15))
+              .fill(Color.primary.opacity(0.15))
               .frame(height: 4)
 
             Capsule()
-              .fill(Color.white.opacity(0.8))
+              .fill(Color.accentColor)
               .frame(width: max(4, geometry.size.width * CGFloat(value)), height: 4)
               .animation(.easeInOut(duration: 0.3), value: value)
           }
@@ -401,7 +404,7 @@ public struct AudiobookPlayerView: View {
 
         Text("\(Int(value * 100))%")
           .font(.system(size: 11, weight: .medium, design: .rounded))
-          .foregroundColor(.white.opacity(0.6))
+          .foregroundColor(.secondary)
           .frame(width: 34, alignment: .trailing)
           .monospacedDigit()
       }
@@ -409,7 +412,7 @@ public struct AudiobookPlayerView: View {
 
       Text(Strings.ScrubberView.downloading)
         .font(.system(size: 11, weight: .medium))
-        .foregroundColor(.white.opacity(0.45))
+        .foregroundColor(.secondary)
     }
     .padding(.vertical, playbackModel.isDownloading ? 8 : 0)
     .frame(height: playbackModel.isDownloading ? nil : 0)

--- a/PalaceAudiobookToolkitTests/AudiobookPlaybackModelTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookPlaybackModelTests.swift
@@ -1,0 +1,43 @@
+//
+//  AudiobookPlaybackModelTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  Regression coverage for PP-4156 — download indicator visibility.
+//
+
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+final class AudiobookPlaybackModelTests: XCTestCase {
+  // MARK: - PP-4156 — download-indicator visibility rule
+  //
+  // The download indicator must be visible whenever overall download progress is
+  // less than 1.0, regardless of player type. A prior commit branched on
+  // `audiobookManager.audiobook.player is LCPStreamingPlayer` and forced
+  // `isDownloading = false` for LCP titles, which silently hid the indicator
+  // while LCP tracks were decrypting in the background.
+  //
+  // The rule lives on AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress:),
+  // a static function whose signature accepts only progress. Re-introducing player-type
+  // branching would require changing the signature, which would fail this build.
+
+  func test_shouldShowDownloadIndicator_isVisibleAtZeroProgress() {
+    XCTAssertTrue(AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: 0.0))
+  }
+
+  func test_shouldShowDownloadIndicator_isVisibleAtPartialProgress() {
+    XCTAssertTrue(AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: 0.01))
+    XCTAssertTrue(AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: 0.5))
+    XCTAssertTrue(AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: 0.999))
+  }
+
+  func test_shouldShowDownloadIndicator_isHiddenAtCompleteProgress() {
+    XCTAssertFalse(AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: 1.0))
+  }
+
+  func test_shouldShowDownloadIndicator_isHiddenAboveCompleteProgress() {
+    // Defensive: NetworkService now clamps to monotonic-max, but if a future change
+    // ever published a value > 1, the indicator must remain hidden — not flicker on.
+    XCTAssertFalse(AudiobookPlaybackModel.shouldShowDownloadIndicator(forOverallProgress: 1.5))
+  }
+}


### PR DESCRIPTION
## Summary

Two stacked regressions in the audiobook player made the download-progress indicator silently invisible for every audiobook on every light-mode device. Both bugs landed in routine "polish" commits — one a 1-line binding change, the other a UI color refresh — and neither was caught at review time. The combined effect: tracks downloaded in the background but the user had no UI feedback that work was happening.

This PR fixes both, factors the visibility rule into a typed seam to prevent re-introduction, and adds 4 boundary unit tests. The end-to-end regression journey lives in the parent ios-core repo (`.simdrive/journeys/audiobook-download-indicator-stateful.yaml`).

## Root cause

### Bug 1: LCP-streaming exclusion (`AudiobookPlaybackModel.swift`)

Commit `e5d5f13` (Jan 15) added a one-line player-type branch:

```swift
let isLCPStreaming = audiobookManager.audiobook.player is LCPStreamingPlayer
isDownloading = !isLCPStreaming && overallProgress < 1
```

This hard-coded `isDownloading = false` whenever the player was `LCPStreamingPlayer`. `AudiobookPlayerView` collapses the indicator's frame to height 0 when `isDownloading` is false (`frame(height: isDownloading ? nil : 0)`), so for every LCP audiobook the indicator simply did not render — even while `LCPDownloadTask` was actively decrypting tracks in the background. Findaway and OpenAccess paths were unaffected.

### Bug 2: White-on-white indicator (`AudiobookPlayerView.swift`)

Commit `4f738d9` (Mar 19, "Smooth cover loading, modern download progress, and adaptive typography") gave the indicator's icon, fill bar, percentage, and "Downloading..." caption `.white.opacity(0.6/0.15/0.8/0.45)` foreground colors. Against the player's system background (white in light mode), this rendered as white-on-white — invisible regardless of the `isDownloading` flag. **This bug affected ALL audiobook types in light mode**, which is why PP-4156 said "for all audiobooks."

## Fix

- **`AudiobookPlaybackModel.swift`**: removed the LCP-streaming branch; routed visibility through a new `shouldShowDownloadIndicator(forOverallProgress:)` static helper. The function signature takes only progress — re-introducing player-type branching would require changing the signature, which would fail the build. The rule extraction provides a typed seam against future re-introduction of the same regression.

- **`AudiobookPlayerView.swift`**: replaced `.white.opacity(...)` with semantic colors (`.secondary` for icon/percentage/caption, `.primary.opacity(0.15)` for the track, `.accentColor` for the fill). Adapts to light/dark mode automatically.

## Verification

A/B test on iPhone 17 Pro sim with **Anna Karenina** (LCP audiobook from A1QA Test Library "Unlimited Listens ODL Feed", 40 hr 59 min remaining). LCP path confirmed by sha256-hashed `.mp3` cache filenames matching `LCPDownloadTask.decryptedFileURL(for:)` source pattern.

| State | Indicator | Screenshot |
|---|---|---|
| **Unfixed** | Absent (frame collapsed to 0) | `observe-1777928378746.png` |
| **Fixed** | Visible at 6%, "Downloading…" + percentage rendered | `observe-1777928534761.png` |

Same audiobook, same simulator, same login, same network. The only variable was source code state — rules out flakiness or environmental confounds.

Findaway sanity-check on Dune (also A1QA): indicator visible after fix, confirming Fix 2 applies uniformly.

## Test plan

- [x] `xcodebuild -scheme PalaceAudiobookToolkit test` — `AudiobookPlaybackModelTests` 4/4 passing in 0.003s
- [x] Boundary coverage: 0.0, partial (0.01/0.5/0.999), 1.0, >1.0
- [x] Manual A/B on a confirmed LCP audiobook with downloads in progress
- [x] Findaway sanity-check (no regression on non-LCP path)
- [x] Build clean for both Palace and Palace-noDRM targets
- [ ] Companion ios-core PR (bumps submodule pointer + adds simdrive regression journey + retrospective doc)

## Notes for reviewers

- 2 unrelated pre-existing failing tests in this repo (`testPP3594_audiobookProgress_throttlesAnnouncements`, `testOriginHost_noSelfLink_returnsNil`) are out of scope here and flagged for a separate cleanup pass. Surfaced in the parent retrospective doc.
- The `shouldShowDownloadIndicator(forOverallProgress:)` extraction is a single-line helper. The point isn't reuse — it's locking the rule's input set in the type system so that anyone re-adding player-type branching has to either change the signature (visible in code review) or bypass the helper entirely (also visible in review).

ForgeOS: `cs_6857deda` — all gates passed.