### PR TITLE
OpenAccessDownloadTask: bounded retry on transient network errors (HelpSpot 17725)

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		8CF57BDC2432788C0053C31E /* Data+BigEndian.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF57BDB2432788C0053C31E /* Data+BigEndian.swift */; };
 		A9DC9CFD220547F800D122F2 /* ErrorDescriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */; };
 		BTRF00012F1900030000001B /* BearerTokenRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BTRF00012F1900030000001A /* BearerTokenRefreshTests.swift */; };
+		51A60E3AFDF6482AB2FECA5A /* ChunkStallRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0BA890FAA749DAA0A58139 /* ChunkStallRetryTests.swift */; };
 		C822F18BA3A94D16A7295A38 /* SpeedSliderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC08A6FDAE14519BD997FE3 /* SpeedSliderSheet.swift */; };
 		D5A0909C2B97986500C0FF2F /* theBigFail_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = D5A0909B2B97986500C0FF2F /* theBigFail_manifest.json */; };
 		E50121752BB498BE0049730D /* animalFarm_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E50121732BB493670049730D /* animalFarm_manifest.json */; };
@@ -224,6 +225,7 @@
 		A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDescriptions.swift; sourceTree = "<group>"; };
 		BFC08A6FDAE14519BD997FE3 /* SpeedSliderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedSliderSheet.swift; sourceTree = "<group>"; };
 		BTRF00012F1900030000001A /* BearerTokenRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BearerTokenRefreshTests.swift; sourceTree = "<group>"; };
+		AF0BA890FAA749DAA0A58139 /* ChunkStallRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkStallRetryTests.swift; sourceTree = "<group>"; };
 		D5A0909B2B97986500C0FF2F /* theBigFail_manifest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = theBigFail_manifest.json; sourceTree = "<group>"; };
 		E50121732BB493670049730D /* animalFarm_manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = animalFarm_manifest.json; sourceTree = "<group>"; };
 		E503256C27FE8EFA00317F68 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				E52C1C3F2C00435700D8F30B /* ManifestJSON.swift */,
 				F0AB00142E8E500100000013 /* AudiobookAccessibilityAnnouncementCenterTests.swift */,
 				BTRF00012F1900030000001A /* BearerTokenRefreshTests.swift */,
+				AF0BA890FAA749DAA0A58139 /* ChunkStallRetryTests.swift */,
 			);
 			path = PalaceAudiobookToolkitTests;
 			sourceTree = "<group>";
@@ -914,6 +917,7 @@
 				E5CC0CFE2BA8ADA0001BF751 /* TrackPositionTests.swift in Sources */,
 				F0AB00132E8E500100000012 /* AudiobookAccessibilityAnnouncementCenterTests.swift in Sources */,
 				BTRF00012F1900030000001B /* BearerTokenRefreshTests.swift in Sources */,
+				51A60E3AFDF6482AB2FECA5A /* ChunkStallRetryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -40,6 +40,19 @@ final class OpenAccessDownloadTask: DownloadTask {
   var fulfillURL: URL?
   private var hasAttemptedTokenRefresh = false
 
+  /// Once-per-task guard for the transient-network-error retry. Re-armed on
+  /// successful download completion in `didFinishDownloadingTo`. Prevents an
+  /// infinite retry loop while still recovering from a single transient blip
+  /// (server returns no HTTP response, idle stall, dropped TCP mid-transfer).
+  /// Helpspot 17725 (audiobook reaches halfway, then "error 914").
+  private var hasAttemptedNetworkRetry = false
+
+  /// Delay before retrying after a transient network failure. Mirrors
+  /// `DownloadWatchdog.Configuration.default.retryDelay` (5s) so behaviour is
+  /// consistent whether the retry comes from this inline path or the
+  /// (currently un-wired) watchdog path.
+  static let NetworkRetryDelay: TimeInterval = 5.0
+
   /// Set when the server returns 403 Forbidden. Prevents infinite retry loops
   /// that effectively DDoS the content server.
   var isForbidden = false
@@ -424,6 +437,60 @@ final class OpenAccessDownloadTask: DownloadTask {
     task.resume()
     return true
   }
+
+  /// Attempts a single retry after a transient network error
+  /// (server returned no HTTP response, idle stall mid-transfer, dropped
+  /// connection). Returns `true` if a retry was scheduled, `false` if the
+  /// retry budget for this task instance is already exhausted.
+  ///
+  /// HelpSpot 17725: audiobook chunk downloads were stalling mid-transfer
+  /// (e.g. "reached about the halfway point before it seemed to stall...
+  /// error 914"). The pre-fix behaviour surfaced a terminal `connectionLost`
+  /// error to the publisher on the first transient blip, so the rest of the
+  /// audiobook was lost even though the next request would have succeeded.
+  ///
+  /// The retry is once per task instance (re-armed on successful completion
+  /// via `didFinishDownloadingTo`) and waits `NetworkRetryDelay` seconds
+  /// before re-fetching, giving the network a chance to recover and avoiding
+  /// hammering an origin that is genuinely down.
+  ///
+  /// Note: this is intentionally narrower than the full `DownloadWatchdog`
+  /// retry budget (3 attempts with backoff). Keeping it bounded to one
+  /// inline retry preserves "fail fast for the user" behaviour for genuine
+  /// outages while recovering the dominant case (single transient blip
+  /// during a long chunk download).
+  func attemptNetworkRetryAfterTransientError() -> Bool {
+    guard !hasAttemptedNetworkRetry else { return false }
+    hasAttemptedNetworkRetry = true
+
+    ATLog(.info, "OpenAccessDownloadTask: Scheduling network-retry in \(Self.NetworkRetryDelay)s for: \(key)")
+
+    session?.invalidateAndCancel()
+    session = nil
+    downloadTask = nil
+
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.NetworkRetryDelay) { [weak self] in
+      guard let self else { return }
+      ATLog(.info, "OpenAccessDownloadTask: Retrying download after transient network error: \(self.key)")
+      self.fetch()
+    }
+    return true
+  }
+
+  /// Re-arms the once-per-task network-retry guard. Called by the URLSession
+  /// delegate on successful download completion so a future re-download
+  /// (after delete + re-borrow, or app relaunch + retry) starts with a fresh
+  /// single-retry budget. Internal-by-default; tests bypass through
+  /// `@testable import` and call this to reset state between assertions.
+  func resetNetworkRetryBudget() {
+    hasAttemptedNetworkRetry = false
+  }
+
+  /// Test seam — read-only view of the once-per-task retry guard. Used by
+  /// unit tests to assert state without poking private storage.
+  var hasUsedNetworkRetry: Bool {
+    hasAttemptedNetworkRetry
+  }
 }
 
 // MARK: - DownloadTaskURLSessionDelegate
@@ -467,10 +534,16 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
       verifyDownloadAndMove(from: location, to: finalURL) { success in
         if success {
           ATLog(.debug, "File successfully downloaded and moved to: \(self.finalURL)")
-          
+
+          // Re-arm the network-retry guard so a future re-download (e.g. user
+          // deletes and re-borrows) gets a fresh single-retry budget.
+          if let oaTask = self.downloadTask as? OpenAccessDownloadTask {
+            oaTask.resetNetworkRetryBudget()
+          }
+
           // Clear any saved resume data since download completed successfully
           DownloadPersistenceStore.shared.removeResumeData(forTrackKey: self.trackKey)
-          
+
           if FileManager.default.fileExists(atPath: location.path) {
             do {
               try FileManager.default.removeItem(at: location)
@@ -539,7 +612,20 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
       switch code {
       case NSURLErrorNotConnectedToInternet,
            NSURLErrorTimedOut,
-           NSURLErrorNetworkConnectionLost:
+           NSURLErrorNetworkConnectionLost,
+           NSURLErrorBadServerResponse,
+           NSURLErrorCannotConnectToHost,
+           NSURLErrorDNSLookupFailed:
+        // HelpSpot 17725: try a single bounded retry before publishing the
+        // terminal connectionLost error. Recovers the dominant case (one
+        // transient blip mid-chunk-download) without hammering an origin
+        // that is genuinely down. Cap is per-task-instance, re-armed on
+        // successful completion in `didFinishDownloadingTo`.
+        if let oaTask = self.downloadTask as? OpenAccessDownloadTask,
+           oaTask.attemptNetworkRetryAfterTransientError() {
+          ATLog(.info, "DownloadTaskDelegate: transient network error (\(code)) for \(self.downloadTask.key) — retry scheduled, suppressing terminal error")
+          return
+        }
         let networkLossError = NSError(
           domain: OpenAccessPlayerErrorDomain,
           code: OpenAccessPlayerError.connectionLost.rawValue,

--- a/PalaceAudiobookToolkitTests/ChunkStallRetryTests.swift
+++ b/PalaceAudiobookToolkitTests/ChunkStallRetryTests.swift
@@ -1,0 +1,150 @@
+//
+//  ChunkStallRetryTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  Tests for HelpSpot 17725: audiobook chunk-download retry on transient
+//  network errors (server returns no HTTP response, idle stall mid-transfer,
+//  dropped TCP). Mirrors the BearerTokenRefreshTests guard-semantics pattern.
+//
+//  Why this matters:
+//  Patron 17725 reported "audiobook... reached about the halfway point
+//  before it seemed to stall... error 914" (914 = invalidOrNoHTTPResponse
+//  in ios-core's TPPErrorCode). Pre-fix, OpenAccessDownloadTask published a
+//  terminal `connectionLost` error to its publisher on the first transient
+//  blip, killing the rest of the audiobook download. The fix adds a single
+//  bounded inline retry (5s delay) before publishing the terminal error,
+//  re-armed on successful completion.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Combine
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+final class ChunkStallRetryTests: XCTestCase {
+
+    // MARK: - Test fixtures
+
+    private func makeTask(token: String? = "test-token") -> OpenAccessDownloadTask {
+        OpenAccessDownloadTask(
+            key: "test-track-key",
+            downloadURL: URL(string: "https://example.com/track.mp3")!,
+            urlString: "https://example.com/track.mp3",
+            urlMediaType: .audioMPEG,
+            alternateLinks: nil,
+            feedbooksProfile: nil,
+            token: token
+        )
+    }
+
+    // MARK: - attemptNetworkRetryAfterTransientError — guard semantics
+
+    /// Default state: the retry budget is fully available (one retry per
+    /// task instance). First call should return true.
+    func testAttemptRetry_freshTask_returnsTrue() {
+        let task = makeTask()
+
+        XCTAssertFalse(task.hasUsedNetworkRetry, "Pre-condition: a fresh task has not used its retry budget")
+
+        let result = task.attemptNetworkRetryAfterTransientError()
+
+        XCTAssertTrue(result, "First call on a fresh task must schedule a retry")
+        XCTAssertTrue(task.hasUsedNetworkRetry, "Calling attempt must consume the once-per-task budget")
+    }
+
+    /// Second call on the same task instance must return false — protects
+    /// against retry storms when the underlying problem is persistent.
+    func testAttemptRetry_secondAttemptOnSameTask_returnsFalse() {
+        let task = makeTask()
+
+        let first = task.attemptNetworkRetryAfterTransientError()
+        XCTAssertTrue(first)
+
+        let second = task.attemptNetworkRetryAfterTransientError()
+
+        XCTAssertFalse(second, "Second retry attempt on the same task instance must return false (one inline retry per task)")
+    }
+
+    /// Successful download re-arms the budget. The URLSession delegate
+    /// calls `resetNetworkRetryBudget()` on `didFinishDownloadingTo` after
+    /// a successful move; this test exercises that contract directly.
+    func testAttemptRetry_reArmedAfterSuccessfulCompletion() {
+        let task = makeTask()
+
+        XCTAssertTrue(task.attemptNetworkRetryAfterTransientError(),
+                      "First retry should fire")
+        XCTAssertFalse(task.attemptNetworkRetryAfterTransientError(),
+                       "Second retry on same task should be blocked")
+
+        task.resetNetworkRetryBudget()
+
+        XCTAssertFalse(task.hasUsedNetworkRetry,
+                       "resetNetworkRetryBudget must clear the once-per-task flag")
+        XCTAssertTrue(task.attemptNetworkRetryAfterTransientError(),
+                      "After reset, retry budget should be available again")
+    }
+
+    /// Each task instance has its own retry budget — exhausting one must
+    /// not affect another. Locks against any accidental shared state
+    /// (e.g. a static counter slipping in during a refactor).
+    func testAttemptRetry_budgetIsPerTaskInstance() {
+        let taskA = makeTask()
+        let taskB = makeTask()
+
+        XCTAssertTrue(taskA.attemptNetworkRetryAfterTransientError(),
+                      "taskA first retry should fire")
+        XCTAssertFalse(taskA.attemptNetworkRetryAfterTransientError(),
+                       "taskA second retry should be blocked")
+
+        XCTAssertFalse(taskB.hasUsedNetworkRetry,
+                       "taskB must not be affected by taskA's exhausted budget")
+        XCTAssertTrue(taskB.attemptNetworkRetryAfterTransientError(),
+                      "taskB should still have its full budget — per-instance, not shared")
+    }
+
+    // MARK: - Configuration
+
+    /// The retry delay must match the watchdog's `default.retryDelay` so
+    /// behaviour is consistent whether retry comes from this inline path or
+    /// the (currently un-wired) `DownloadWatchdog` path.
+    func testNetworkRetryDelay_matchesWatchdogDefault() {
+        XCTAssertEqual(
+            OpenAccessDownloadTask.NetworkRetryDelay,
+            DownloadWatchdog.Configuration.default.retryDelay,
+            "Inline retry delay must match the watchdog's default for consistent UX"
+        )
+    }
+
+    /// The retry delay must be > 0 — a 0s delay would effectively be a
+    /// busy-loop on whatever transient error the network layer just hit.
+    func testNetworkRetryDelay_isPositive() {
+        XCTAssertGreaterThan(
+            OpenAccessDownloadTask.NetworkRetryDelay,
+            0,
+            "NetworkRetryDelay must be > 0 to give the network time to recover before re-fetching"
+        )
+    }
+
+    // MARK: - Regression guard for HelpSpot 17725
+
+    /// The fix-is-real test. Asserts the exact patron scenario fingerprint:
+    /// a single transient network error mid-download must NOT kill the
+    /// download — the retry budget kicks in. Pre-fix this returned false
+    /// (no retry method existed) and the publisher got a terminal
+    /// connectionLost error on the first blip.
+    func testRegressionForBug_singleTransientErrorIsRetried_perHelpSpot17725() {
+        let task = makeTask()
+
+        // Simulate the network-layer arriving at the transient-error path
+        // with the budget intact — this is exactly what the URLSession
+        // delegate does on NSURLErrorTimedOut / NSURLErrorBadServerResponse
+        // / NSURLErrorNetworkConnectionLost / etc.
+        let didRetry = task.attemptNetworkRetryAfterTransientError()
+
+        XCTAssertTrue(
+            didRetry,
+            "REGRESSION GUARD (HelpSpot 17725): a single transient network error mid-chunk-download must trigger an inline retry instead of publishing a terminal connectionLost error"
+        )
+    }
+}


### PR DESCRIPTION
**JIRA:** [PP-4277](https://ebce-lyrasis.atlassian.net/browse/PP-4277)

## Summary

- **Bug:** Audiobook chunk downloads were dying on the first transient network blip mid-transfer. The `urlSession(_:task:didCompleteWithError:)` delegate path mapped `NSURLErrorTimedOut` / `NetworkConnectionLost` / `NotConnectedToInternet` to a terminal `connectionLost` error and published it. Patron-visible symptom (HelpSpot 17725,): "audiobook... reached about the halfway point before it seemed to stall... error 914".
- **Fix:** Bounded once-per-task inline retry. Before publishing the terminal error, the delegate now invokes `OpenAccessDownloadTask.attemptNetworkRetryAfterTransientError()` which schedules `fetch()` after a 5-second delay (matching `DownloadWatchdog.Configuration.default.retryDelay` so behaviour is consistent). Retry budget re-arms on successful completion in `didFinishDownloadingTo`.
- **Expanded transient-error case set** to include `NSURLErrorBadServerResponse`, `NSURLErrorCannotConnectToHost`, and `NSURLErrorDNSLookupFailed` — all "single blip mid-transfer" patterns the watchdog would catch (if wired up).
- **7 unit tests** in `ChunkStallRetryTests.swift` lock the retry guard semantics: fresh task gets a retry, second attempt blocked, reset re-arms, budget is per-task-instance not shared, delay matches watchdog default. Includes named regression guard for HelpSpot 17725.

## HelpSpot tickets addressed

- **17725** — (): "audiobook... reached about the halfway point before it seemed to stall... error 914".

## Why intentionally narrower than `DownloadWatchdog`

The toolkit already has a well-built `DownloadWatchdog` (3 retries with backoff, stall detection) but it's not currently wired into `DefaultAudiobookNetworkService` — zero callers of `createWatchdog()` outside its own definition. Wiring the watchdog up is a separate larger architectural change that needs proper end-to-end QA. One inline retry per task here recovers the dominant case (single transient blip) without that wiring.

The watchdog's `deinit`-via-`stop()` crash (Crashlytics `738711ca PalaceAudiobookToolkit DownloadWatchdog.stop` — 10 events / 2 users on Palace 3.0.0) is **already fixed on `main`** via PR #168 (a84d693 "Fix DownloadWatchdog teardown race"). The ios-core submodule pointer (`bc8ffbe`) is just behind — a separate trivial submodule-bump PR in ios-core picks it up.

## Test plan

- [x] 7/7 `ChunkStallRetryTests` pass via `Palace.xcodeproj` `PalaceAudiobookToolkit` scheme on iPhone 16 Pro / iOS 26.2 sim.
- [x] No new compiler warnings on changed files.
- [ ] End-to-end test driving a stubbed-failure-then-success URLSession isn't included — would need a stub origin or simdrive flow with controllable network behavior. Unit tests cover guard semantics + retry contract; manual smoke against a known-flaky server recommended after merge.

## Out of scope / deferred

- Wiring `DownloadWatchdog` into `DefaultAudiobookNetworkService` for the full 3-retry-with-backoff pattern (separate architectural change with QA partner).
- Equivalent retry on `OverdriveDownloadTask` and `LCPDownloadTask` (this PR scopes to `OpenAccessDownloadTask` since that's what the patron's symptom hits; the other two have their own download paths and would need parallel investigation).
- Per-chunk progressive backoff if multiple retries become wanted in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PP-4277]: https://ebce-lyrasis.atlassian.net/browse/PP-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
