### PR TITLE
audiobook: 403 error resilience — typed errors + NSURLErrorDomain bridge

### DIFF
--- a/PalaceAudiobookToolkit/Core/ErrorDescriptions.swift
+++ b/PalaceAudiobookToolkit/Core/ErrorDescriptions.swift
@@ -10,6 +10,7 @@ enum OpenAccessPlayerError: Int {
   case connectionLost
   case drmExpired
   case authenticationRequired
+  case contentForbidden
 
   func errorTitle() -> String {
     switch self {
@@ -21,6 +22,8 @@ enum OpenAccessPlayerError: Int {
       "DRM Protection"
     case .authenticationRequired:
       "Sign In Required"
+    case .contentForbidden:
+      "Title Unavailable"
     default:
       "A Problem Has Occurred"
     }
@@ -54,6 +57,11 @@ enum OpenAccessPlayerError: Int {
     case .authenticationRequired:
       """
       Your session has expired. Please sign in to your library account to continue listening.
+      """
+    case .contentForbidden:
+      """
+      This audiobook is no longer available from the publisher. Please return it and try a \
+      different title. If the problem persists, contact your library.
       """
     }
   }

--- a/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -577,6 +577,24 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
          let oaTask = self.downloadTask as? OpenAccessDownloadTask {
         ATLog(.error, "DownloadTaskDelegate: 403 Forbidden for: \(self.downloadTask.key) — will not retry")
         oaTask.isForbidden = true
+
+        // Publish a typed error with HTTP status + URL context so the player
+        // surfaces a specific message ("Title Unavailable") and so Palace can
+        // record a Crashlytics non-fatal with full context. Generic
+        // .error(nil) hid the cause and surfaced as "A Problem Has Occurred"
+        // — the patron got a useless message and Crashlytics got nothing.
+        let forbiddenError = NSError(
+          domain: OpenAccessPlayerErrorDomain,
+          code: OpenAccessPlayerError.contentForbidden.rawValue,
+          userInfo: [
+            NSLocalizedDescriptionKey: OpenAccessPlayerError.contentForbidden.errorDescription(),
+            "httpStatusCode": httpResponse.statusCode,
+            "trackKey": self.downloadTask.key,
+            "url": httpResponse.url?.absoluteString ?? ""
+          ]
+        )
+        statePublisher.send(.error(forbiddenError))
+        return
       }
 
       if httpResponse.statusCode == 401 {
@@ -587,7 +605,19 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
         )
         statePublisher.send(.error(authError))
       } else {
-        statePublisher.send(.error(nil))
+        // Other 4xx/5xx: still publish a typed error so downstream sees the
+        // status code and URL rather than a nil error.
+        let httpError = NSError(
+          domain: OpenAccessPlayerErrorDomain,
+          code: OpenAccessPlayerError.unknown.rawValue,
+          userInfo: [
+            NSLocalizedDescriptionKey: "Server returned HTTP \(httpResponse.statusCode)",
+            "httpStatusCode": httpResponse.statusCode,
+            "trackKey": self.downloadTask.key,
+            "url": httpResponse.url?.absoluteString ?? ""
+          ]
+        )
+        statePublisher.send(.error(httpError))
       }
     }
   }

--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -202,19 +202,42 @@ public class AudiobookPlaybackModel: ObservableObject {
         case .playbackUnloaded:
           _isPlaying = false
           isNavigating = false
-        case let .playbackFailed(position, _):
+        case let .playbackFailed(position, error):
           isWaitingForPlayer = false
           _isPlaying = false
           isNavigating = false
+
+          let nsError = error as NSError?
+          let openAccessError: OpenAccessPlayerError? = {
+            guard let nsError = nsError, nsError.domain == OpenAccessPlayerErrorDomain else { return nil }
+            return OpenAccessPlayerError(rawValue: nsError.code)
+          }()
+
           if let position = position {
             ATLog(.error, "🚨 [AudiobookPlaybackModel] Playback error at position: \(position.timestamp)")
             ATLog(.error, "  Track: \(position.track.title ?? "unknown")")
-            ATLog(.error, "  This may indicate corrupted file or decryption issues")
+            if let nsError = nsError {
+              let status = nsError.userInfo["httpStatusCode"] as? Int
+              let url = nsError.userInfo["url"] as? String
+              ATLog(.error, "  Underlying error: \(nsError.domain) code=\(nsError.code) http=\(status.map { "\($0)" } ?? "n/a") url=\(url ?? "n/a")")
+            } else {
+              ATLog(.error, "  No underlying error provided — may indicate corrupted file or decryption issues")
+            }
           } else {
             ATLog(.error, "🚨 [AudiobookPlaybackModel] Playback failed but position is nil - possibly SDK crash")
           }
-          
-          let errorMessage = "\(Strings.AudiobookPlayerViewController.problemHasOccurred). \(Strings.AudiobookPlayerViewController.tryAgain)"
+
+          // Surface a specific message when we have one, fall back to generic
+          // only when the error is unknown / nil. Previously every failure
+          // showed "A Problem Has Occurred" — including 403 Forbidden, which
+          // patrons could not act on. Now contentForbidden / connectionLost /
+          // drmExpired / authenticationRequired each get their own copy.
+          let errorMessage: String
+          if let oaError = openAccessError, oaError != .unknown {
+            errorMessage = "\(oaError.errorTitle()). \(oaError.errorDescription())"
+          } else {
+            errorMessage = "\(Strings.AudiobookPlayerViewController.problemHasOccurred). \(Strings.AudiobookPlayerViewController.tryAgain)"
+          }
           ATLog(.error, "  Showing error to user: \(errorMessage)")
           toastMessage = errorMessage
 

--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -209,8 +209,31 @@ public class AudiobookPlaybackModel: ObservableObject {
 
           let nsError = error as NSError?
           let openAccessError: OpenAccessPlayerError? = {
-            guard let nsError = nsError, nsError.domain == OpenAccessPlayerErrorDomain else { return nil }
-            return OpenAccessPlayerError(rawValue: nsError.code)
+            guard let nsError = nsError else { return nil }
+            if nsError.domain == OpenAccessPlayerErrorDomain {
+              return OpenAccessPlayerError(rawValue: nsError.code)
+            }
+            // AVFoundation wraps HTTP 403 as NSURLErrorNoPermissionsToReadFile
+            // (-1102) before the error reaches us — by the time playback hits
+            // the AVPlayerItem, the OpenAccessPlayerError.contentForbidden we
+            // published from OpenAccessDownloadTask has been re-typed by the
+            // system networking layer. Treat -1102 as contentForbidden so the
+            // patron sees "Title Unavailable" instead of generic.
+            if nsError.domain == NSURLErrorDomain {
+              switch nsError.code {
+              case NSURLErrorNoPermissionsToReadFile:
+                return .contentForbidden
+              case NSURLErrorUserAuthenticationRequired:
+                return .authenticationRequired
+              case NSURLErrorNotConnectedToInternet,
+                   NSURLErrorNetworkConnectionLost,
+                   NSURLErrorTimedOut:
+                return .connectionLost
+              default:
+                return nil
+              }
+            }
+            return nil
           }()
 
           if let position = position {


### PR DESCRIPTION
## Summary

Companion submodule PR to ios-core #933. Enables the patron-facing "Title Unavailable" alert (rather than generic "A Problem Has Occurred") on audiobook 403s by surfacing typed errors all the way through to the UI.

## Why this needs to merge first

ios-core #933 bumps the submodule pointer to `cd0363c2`. GitHub Actions does a shallow submodule fetch on PR builds, so that SHA must be reachable from the default branch (`main`) or the ios-core build fails with `upload-pack: not our ref`. Merging this PR puts both commits on `main`, unblocking the ios-core build.

## What changes

**`4a5789cb` — surface typed errors on download/playback failure**

- `ErrorDescriptions.swift`: adds `case contentForbidden` with patron-readable "Title Unavailable" / "This audiobook is no longer available from the publisher…" copy.
- `OpenAccessDownloadTask.swift`: on HTTP 403, publish `OpenAccessPlayerError.contentForbidden` (was falling through to `.error(nil)`, which became a generic toast at playback time and produced zero Crashlytics records).

**`cd0363c2` — bridge NSURLErrorDomain → OpenAccessPlayerError in UI**

AVFoundation re-wraps HTTP 403 (and related auth/network conditions) as `NSURLErrorDomain` codes by the time they reach `AudiobookPlaybackModel.playbackFailed` — so the typed error we publish from `OpenAccessDownloadTask` gets translated through the system layer and the UI saw NSURLErrorDomain it didn't recognise. Maps NSURLErrorDomain codes back to the OpenAccessPlayerError equivalents:

- `NSURLErrorNoPermissionsToReadFile` (-1102) → `.contentForbidden`
- `NSURLErrorUserAuthenticationRequired` (-1013) → `.authenticationRequired`
- `NSURLErrorNotConnectedToInternet` / `NetworkConnectionLost` / `TimedOut` → network family
- Other codes preserved

## Live verification (3.1.0/470 on F3CB599D)

- ✅ Tap **Listen** on a 403'd audiobook → "Title Unavailable. This audiobook is no longer available from the publisher…" displayed (previously: generic alert)
- ✅ Crashlytics non-fatal fires correctly with the `contentForbidden` classification preserved on the Palace side (via #933)

## Risk profile

- 2 commits, scoped to OpenAccess playback error paths
- No DRM (Adobe/LCP) code touched
- No protocol changes
- Pairs with ios-core #933, which adds tests for all 4 error families on the Palace side

## Test plan

- [x] Live-verified on F3CB599D 3.1.0/470 patron account
- [ ] Merge order: this PR first, then ios-core #933 bumps the submodule pointer to the merge commit on `main`