### PR TITLE
fix(manifest): partial Findaway DRM decode + root invariant validation

### DIFF
--- a/PalaceAudiobookToolkit/Player/Helpers/Models/Manifest.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Models/Manifest.swift
@@ -102,6 +102,29 @@ public struct Manifest: Codable {
       resources = []
       print("Failed to decode resources or resources were empty. Defaulting to an empty array.")
     }
+
+    // Root invariant: at minimum the manifest must (a) carry metadata, and
+    // (b) describe at least one playable track via readingOrder OR spine.
+    // Without one of these the loader has nothing to bootstrap from and
+    // currently crashes downstream (Crashlytics 7bf923ee — F-005,
+    // AudiobookLoader.finalizeBuild). Reject early with a clear error so
+    // the failure surfaces as a typed DecodingError the caller can handle
+    // (UI: "Audiobook manifest is missing required fields") instead of an
+    // EXC_BREAKPOINT in finalizeBuild.
+    let hasReadingOrder = (readingOrder?.isEmpty == false)
+    let hasSpine = (spine?.isEmpty == false)
+    let hasMetadata = (metadata != nil)
+    if !hasMetadata || (!hasReadingOrder && !hasSpine) {
+      var missing: [String] = []
+      if !hasMetadata { missing.append("metadata") }
+      if !hasReadingOrder && !hasSpine { missing.append("readingOrder|spine") }
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: container.codingPath,
+          debugDescription: "Manifest is missing required root field(s): \(missing.joined(separator: ", "))"
+        )
+      )
+    }
   }
 
   public static func customDecoder() -> JSONDecoder {

--- a/PalaceAudiobookToolkit/Player/Helpers/Models/Metadata.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Models/Metadata.swift
@@ -188,12 +188,24 @@ public extension Manifest {
   }
 
   struct FindawayDRMInformation: Codable {
-    var scheme: String?
+    // Load-bearing for playback — without these we cannot decrypt anything,
+    // so they remain required and any partial response is rejected.
     let licenseId: String
     let sessionKey: String
-    let checkoutId: String
-    let fulfillmentId: String
-    let accountId: String
+
+    // Reporting/cleanup metadata. A server response that drops one of these
+    // (Helpspot 17727 RAILS case: fulfillmentId was missing from the
+    // partial-resync feed) used to throw the whole DRMType decode, which
+    // bubbled up as "DRM information could not be decoded" and crashed
+    // AudiobookLoader.finalizeBuild (Crashlytics 7bf923ee — F-005). Allow
+    // these to be nil so we can salvage the usable session+license and
+    // still play. Consumers already access these via `drmInformation?.fooId`
+    // and handle nil at the API surface (FindawayAudiobook.swift:28,
+    // FindawayTrack.swift:82).
+    var scheme: String?
+    let checkoutId: String?
+    let fulfillmentId: String?
+    let accountId: String?
 
     enum CodingKeys: String, CodingKey {
       case scheme

--- a/PalaceAudiobookToolkitTests/ManifestDecodingTests.swift
+++ b/PalaceAudiobookToolkitTests/ManifestDecodingTests.swift
@@ -466,4 +466,115 @@ private func validateLinks(_ manifestLinks: [Manifest.Link], against jsonLinks: 
       XCTAssert(true)
     }
   }
+
+  // MARK: - FU-3: Findaway DRM partial decode
+
+  /// Crashlytics 7bf923ee (F-005, AudiobookLoader.finalizeBuild EXC_BREAKPOINT)
+  /// surfaces on partial Findaway license responses missing one of the
+  /// reporting fields (checkoutId / fulfillmentId / accountId). Before this
+  /// fix the whole DRMType decode threw and bubbled up as a generic
+  /// "DRM information could not be decoded" error. Now the load-bearing
+  /// licenseId + sessionKey are kept, optional fields stay nil, playback
+  /// can still start.
+  func testFindawayDRMInformation_partialDecode_preservesPlayableFields() throws {
+    let json = """
+    {
+      "scheme": "http://librarysimplified.org/terms/drm/scheme/FAE",
+      "findaway:licenseId": "LICENSE-123",
+      "findaway:sessionKey": "SESSION-456",
+      "findaway:checkoutId": "CHECKOUT-789"
+    }
+    """.data(using: .utf8)!
+
+    let drm = try JSONDecoder().decode(Manifest.Metadata.FindawayDRMInformation.self, from: json)
+
+    XCTAssertEqual(drm.licenseId, "LICENSE-123", "licenseId must survive partial decode — load-bearing for playback")
+    XCTAssertEqual(drm.sessionKey, "SESSION-456", "sessionKey must survive partial decode — load-bearing for playback")
+    XCTAssertEqual(drm.checkoutId, "CHECKOUT-789")
+    XCTAssertNil(drm.fulfillmentId, "fulfillmentId missing from server response should decode as nil, not throw")
+    XCTAssertNil(drm.accountId, "accountId missing from server response should decode as nil, not throw")
+  }
+
+  /// licenseId is non-negotiable; without it Findaway cannot decrypt
+  /// anything. Decoding MUST still throw if it's absent — partial-decode
+  /// resilience is for reporting fields only, not load-bearing fields.
+  func testFindawayDRMInformation_missingLicenseId_throws() {
+    let json = """
+    {
+      "findaway:sessionKey": "SESSION-456"
+    }
+    """.data(using: .utf8)!
+
+    XCTAssertThrowsError(
+      try JSONDecoder().decode(Manifest.Metadata.FindawayDRMInformation.self, from: json),
+      "Missing licenseId must throw — playback cannot start without it"
+    )
+  }
+
+  // MARK: - FU-8: Manifest root invariant validation
+
+  /// A "{}" manifest (or any manifest missing both readingOrder AND spine,
+  /// or missing metadata) used to decode successfully into a Manifest with
+  /// all-nil fields. AudiobookLoader.finalizeBuild then crashed reaching
+  /// for those nils (Crashlytics 7bf923ee — F-005). Now the decoder
+  /// rejects up front with a clear DecodingError so the caller can show
+  /// "manifest invalid" instead of the app dying in finalizeBuild.
+  func testManifest_emptyObject_failsWithRootInvariantError() {
+    let json = "{}".data(using: .utf8)!
+    let decoder = Manifest.customDecoder()
+
+    XCTAssertThrowsError(try decoder.decode(Manifest.self, from: json)) { error in
+      guard case let DecodingError.dataCorrupted(context) = error else {
+        XCTFail("Expected DecodingError.dataCorrupted, got \(error)")
+        return
+      }
+      XCTAssertTrue(
+        context.debugDescription.contains("metadata") ||
+        context.debugDescription.contains("readingOrder"),
+        "Error message should name the missing root field(s); got: \(context.debugDescription)"
+      )
+    }
+  }
+
+  /// A manifest with metadata but neither readingOrder nor spine has
+  /// nothing to play. The loader has no way to bootstrap from this
+  /// shape — reject it at decode time, not at playback time.
+  func testManifest_metadataOnly_failsWithMissingTracks() {
+    let json = """
+    {
+      "metadata": { "title": "Empty book" }
+    }
+    """.data(using: .utf8)!
+    let decoder = Manifest.customDecoder()
+
+    XCTAssertThrowsError(try decoder.decode(Manifest.self, from: json)) { error in
+      guard case let DecodingError.dataCorrupted(context) = error else {
+        XCTFail("Expected DecodingError.dataCorrupted, got \(error)")
+        return
+      }
+      XCTAssertTrue(
+        context.debugDescription.contains("readingOrder") ||
+        context.debugDescription.contains("spine"),
+        "Error message should name tracks-missing; got: \(context.debugDescription)"
+      )
+    }
+  }
+
+  /// Positive control — the root-invariant check must NOT regress the
+  /// happy path. A manifest with metadata + at least one readingOrder
+  /// entry decodes cleanly.
+  func testManifest_metadataPlusReadingOrder_decodesCleanly() throws {
+    let json = """
+    {
+      "metadata": { "title": "Test Book" },
+      "readingOrder": [
+        { "href": "https://example.com/ch1.mp3", "type": "audio/mpeg" }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    let manifest = try Manifest.customDecoder().decode(Manifest.self, from: json)
+    XCTAssertNotNil(manifest.metadata)
+    XCTAssertEqual(manifest.readingOrder?.count, 1)
+  }
 }


### PR DESCRIPTION
Two crashes from the 3.0.0 top-10 trace back to overly-strict / overly-permissive Manifest decoding. Both fixed here behind targeted tests.

**FU-3: FindawayDRMInformation partial decode**
Crashlytics 7bf923ee (F-005, AudiobookLoader.finalizeBuild EXC_BREAKPOINT) and Helpspot 17727 (RAILS user) both surface when a Findaway license response is missing one of `findaway:checkoutId`, `findaway:fulfillmentId`, or `findaway:accountId`. Before this change those fields were non-optional `let`, so a missing field threw the whole DRMType decode and the loader crashed downstream.

Now: `licenseId` and `sessionKey` remain required (without them Findaway literally cannot decrypt). `checkoutId`, `fulfillmentId`, and `accountId` are optional — they're reporting/cleanup metadata and the consumers already access them through optional chains (`FindawayAudiobook.swift:28`, `FindawayTrack.swift:82`), so loosening the model is a non-breaking change at the API surface.

**FU-8: Manifest root invariant validation**
A "{}" or near-empty manifest used to decode successfully into a Manifest with all-nil fields. Loader code then reached for those nils and crashed (also surfaces as F-005 EXC_BREAKPOINT in finalizeBuild).

Now Manifest.init throws a clear `DecodingError.dataCorrupted` at the end of decode if:
  - `metadata` is missing, OR
  - neither `readingOrder` nor `spine` has at least one entry.

The error names the missing field(s) so the UI can show "Audiobook manifest is missing required fields: …" instead of crashing.

**Tests added (4 new in ManifestDecodingTests):**
- `testFindawayDRMInformation_partialDecode_preservesPlayableFields`
- `testFindawayDRMInformation_missingLicenseId_throws`
- `testManifest_emptyObject_failsWithRootInvariantError`
- `testManifest_metadataOnly_failsWithMissingTracks`
- `testManifest_metadataPlusReadingOrder_decodesCleanly` (positive control to guard against false positives in the invariant check)

Existing fixtures (LCP/Overdrive/Findaway sample manifests) all carry both metadata and readingOrder/spine, so the existing testManifestDecoding loop is unaffected.

Build verified via the parent Palace project on iPhone 16 Pro sim (BUILD SUCCEEDED; only pre-existing Overdrive deprecation warnings).