### PR TITLE
audiobook: keep NowPlaying timer alive in background (HelpSpot 17865)

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7B6C1BD420405C4D00EB791E /* CursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6C1BD320405C4D00EB791E /* CursorTests.swift */; };
 		7B78545B204DEE8500F6589B /* AudiobookNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */; };
 		PP41560001AAAA0001AAAA01 /* AudiobookPlaybackModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */; };
+		PP17865001AAAA0001AAAA01 /* AudiobookManagerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP17865001AAAA0001AAAA00 /* AudiobookManagerLifecycleTests.swift */; };
 		7B78545D204DEE9900F6589B /* DownloadTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */; };
 		7B7B370820211CE100030A1E /* OpenAccessDownloadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7B370720211CE100030A1E /* OpenAccessDownloadTask.swift */; };
 		7B8026A3206AB0AF00012808 /* HumanReadablePlaybackRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8026A2206AB0AF00012808 /* HumanReadablePlaybackRate.swift */; };
@@ -197,6 +198,7 @@
 		7B6C1BD320405C4D00EB791E /* CursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorTests.swift; sourceTree = "<group>"; };
 		7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookNetworkServiceTest.swift; sourceTree = "<group>"; };
 		PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookPlaybackModelTests.swift; sourceTree = "<group>"; };
+		PP17865001AAAA0001AAAA00 /* AudiobookManagerLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookManagerLifecycleTests.swift; sourceTree = "<group>"; };
 		7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadTaskMock.swift; sourceTree = "<group>"; };
 		7B7B370720211CE100030A1E /* OpenAccessDownloadTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAccessDownloadTask.swift; sourceTree = "<group>"; };
 		7B8026A2206AB0AF00012808 /* HumanReadablePlaybackRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HumanReadablePlaybackRate.swift; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 				7B54419C200EA7C20047B6C6 /* Info.plist */,
 				7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */,
 				PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */,
+				PP17865001AAAA0001AAAA00 /* AudiobookManagerLifecycleTests.swift */,
 				7B6C1BD320405C4D00EB791E /* CursorTests.swift */,
 				8CD8A20E243E7A0D009DA4CC /* Data+BigEndianTest.swift */,
 				7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */,
@@ -911,6 +914,7 @@
 				7BBF4DFE2050850A00700731 /* SleepTimerTests.swift in Sources */,
 				7B78545B204DEE8500F6589B /* AudiobookNetworkServiceTest.swift in Sources */,
 				PP41560001AAAA0001AAAA01 /* AudiobookPlaybackModelTests.swift in Sources */,
+				PP17865001AAAA0001AAAA01 /* AudiobookManagerLifecycleTests.swift in Sources */,
 				7B78545D204DEE9900F6589B /* DownloadTaskMock.swift in Sources */,
 				E5B05DAA2BA4DB4500686897 /* TableOfContentsTests.swift in Sources */,
 				8C3CDB042422AB060020FC0B /* JSONUtilsTest.swift in Sources */,

--- a/PalaceAudiobookToolkit/Core/AudiobookManager.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookManager.swift
@@ -310,16 +310,24 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
     NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
       .sink { [weak self] _ in
         guard let self = self else { return }
-        ATLog(.debug, "⚡ App became active - restarting optimized timer and updating position")
-        
-        // Immediately capture and update current position for UI sync
-        if let currentPosition = audiobook.player.currentTrackPosition {
-          statePublisher.send(.positionUpdated(currentPosition))
-          updateNowPlayingInfo(currentPosition)
-          ATLog(.debug, "🔒 Immediately updated position on foreground: \(currentPosition.timestamp)")
-        }
-        
+        ATLog(.debug, "⚡ App became active - restarting optimized timer (HelpSpot 17865)")
+
+        // HelpSpot 17865: rebuild the timer FIRST (so the .active 2s cadence
+        // is restored), then defer one main-runloop tick before reading the
+        // player's currentTrackPosition. The previous order (publish-then-
+        // rebuild) raced a stale cached timestamp against the player's
+        // resumed clock and the slider visibly jumped forward by the suspend
+        // duration. Deferring lets the underlying engine refresh first.
         setupNowPlayingInfoTimer()
+
+        DispatchQueue.main.async { [weak self] in
+          guard let self = self else { return }
+          if let currentPosition = audiobook.player.currentTrackPosition {
+            statePublisher.send(.positionUpdated(currentPosition))
+            updateNowPlayingInfo(currentPosition)
+            ATLog(.debug, "🔒 Published refreshed position on foreground: \(currentPosition.timestamp)")
+          }
+        }
       }
       .store(in: &cancellables)
 
@@ -339,16 +347,20 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
     NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
       .sink { [weak self] _ in
         guard let self = self else { return }
-        ATLog(.debug, "⚡ App entered background - pausing timer for energy savings")
-        
+        ATLog(.debug, "⚡ App entered background - rebuilding timer at background interval (HelpSpot 17865)")
+
         // Final position save when entering background
         if let currentPosition = audiobook.player.currentTrackPosition {
           saveLocation(currentPosition)
           ATLog(.debug, "🔒 Final position save on background: \(currentPosition.timestamp)")
         }
-        
-        timer?.cancel()
-        timer = nil
+
+        // HelpSpot 17865: do NOT nil-out the timer here. Rebuild it via
+        // setupNowPlayingInfoTimer() so the .background switch arm (15s
+        // interval, line ~443) becomes reachable and the lock-screen writer
+        // keeps firing. iOS audio-session entitlement permits this cadence
+        // while audio is actively playing.
+        setupNowPlayingInfoTimer()
       }
       .store(in: &cancellables)
     
@@ -591,11 +603,20 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
     
     ATLog(.info, "🔒 [AudiobookManager] Setting nowPlayingInfo - isPlaying: \(isPlaying), rate: \(playbackRate)")
 
+    // HelpSpot 17865: wrap the MPNowPlayingInfoCenter write in a background
+    // task envelope so the system grants us enough wall-time to complete it
+    // when the app is suspending. Otherwise the write can be cut mid-flight
+    // and the lock-screen view goes stale until next resume.
+    let bgTaskID = UIApplication.shared.beginBackgroundTask(withName: "PalaceAudiobookNowPlayingWrite") { }
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-    
+
     // CRITICAL: Also set the playback state explicitly for CarPlay
     MPNowPlayingInfoCenter.default().playbackState = isPlaying ? .playing : .paused
-    
+
+    if bgTaskID != .invalid {
+      UIApplication.shared.endBackgroundTask(bgTaskID)
+    }
+
     ATLog(.info, "🔒 [AudiobookManager] updateNowPlayingInfo COMPLETE - playbackState: \(isPlaying ? "playing" : "paused")")
   }
 

--- a/PalaceAudiobookToolkitTests/AudiobookManagerLifecycleTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookManagerLifecycleTests.swift
@@ -1,0 +1,171 @@
+//
+//  AudiobookManagerLifecycleTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  Regression coverage for HelpSpot 17865 — Audiobook NowPlaying freeze on
+//  background → foreground.
+//
+//  These tests pin two behaviors:
+//  (1) didEnterBackgroundNotification must REBUILD the timer (so the lock-screen
+//      MPNowPlayingInfoCenter writer keeps firing at the .background cadence)
+//      — NOT cancel it outright as a prior commit did.
+//  (2) didBecomeActiveNotification must NOT publish a stale cached position
+//      ahead of the player's resumed clock — the slider would otherwise jump
+//      forward by the suspend duration. Position publish is now deferred a tick
+//      so the player can refresh its internal clock first.
+//
+//  The third behavior from the contract (UIApplication.beginBackgroundTask wrap
+//  around the MPNowPlayingInfoCenter write at AudiobookManager.swift:~594) is
+//  exercised indirectly: this target has no UIApplication shim, and the main
+//  repo's NowPlayingCoordinatorBackgroundTests in ios-core covers the writer
+//  side. Documented as skip below.
+//
+//  Copyright © 2026 The Palace Project. All rights reserved.
+//
+
+import Combine
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+@MainActor
+final class AudiobookManagerLifecycleTests: XCTestCase {
+
+  // MARK: - Fixture helpers
+
+  /// Builds a DefaultAudiobookManager from the `alice_manifest.json` test
+  /// resource. Mirrors `AudiobookNavigationView`'s preview factory but in test
+  /// scope so we exercise the real notification observers + timer machinery.
+  private func makeManager() throws -> (DefaultAudiobookManager, PlayerMock) {
+    let manifest = try Manifest.from(jsonFileName: "alice_manifest", bundle: Bundle(for: type(of: self)))
+    guard let audiobook = OpenAccessAudiobook(manifest: manifest, bookIdentifier: "audiobook-lifecycle-test", decryptor: nil, token: nil) else {
+      throw XCTSkip("OpenAccessAudiobook failed to construct from alice_manifest — fixture problem, not a real failure.")
+    }
+
+    // Replace the real player with a controllable mock so we can drive
+    // currentTrackPosition + isPlaying deterministically.
+    let mockPlayer = PlayerMock(tableOfContents: audiobook.tableOfContents)
+    setMockPlayer(mockPlayer, on: audiobook)
+
+    let manager = DefaultAudiobookManager(
+      metadata: AudiobookMetadata(title: "Lifecycle Test", authors: ["Author"]),
+      audiobook: audiobook,
+      networkService: DefaultAudiobookNetworkService(tracks: audiobook.tableOfContents.allTracks)
+    )
+    return (manager, mockPlayer)
+  }
+
+  /// Overwrite the audiobook's `player` via reflection-friendly setter; the
+  /// property is declared `var` on `Audiobook` so direct assignment works.
+  private func setMockPlayer(_ mock: PlayerMock, on audiobook: Audiobook) {
+    audiobook.player = mock
+  }
+
+  // MARK: - Test 1: didEnterBackgroundNotification rebuilds, does not cancel
+
+  /// HelpSpot 17865 — When the app enters background, the lock-screen writer
+  /// must keep running (at the .background 15s cadence). Prior to this fix
+  /// the notification handler did `timer?.cancel(); timer = nil`, which
+  /// stranded MPNowPlayingInfoCenter — patrons reported their lock-screen
+  /// scrubber froze, and on resume the slider snapped forward.
+  ///
+  /// In a unit-test environment `UIApplication.shared.applicationState` is
+  /// `.background` (XCTest runs headless), so the rebuild actually re-creates
+  /// the timer at the 15s interval. We assert the timer is non-nil after the
+  /// notification — i.e. that the cancel-and-leave-nil bug is gone.
+  func testBackgroundNotification_rebuildsTimerAtBackgroundInterval() throws {
+    let (manager, player) = try makeManager()
+    player.isPlaying = true
+
+    // Sanity: timer is alive after init.
+    XCTAssertNotNil(manager.timer, "Timer should be set up on init.")
+
+    // Act: post the lifecycle notification.
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // The notification handler is wired via Combine .sink which delivers
+    // synchronously on the same queue when no scheduler is interposed, but
+    // setupNowPlayingInfoTimer schedules a Timer.publish on .main. Give it
+    // a runloop tick to settle.
+    let settled = XCTestExpectation(description: "Background handler settled")
+    DispatchQueue.main.async {
+      settled.fulfill()
+    }
+    wait(for: [settled], timeout: 1.0)
+
+    // Assert: timer was rebuilt, not nilled-out. Pre-fix this was nil.
+    XCTAssertNotNil(
+      manager.timer,
+      "didEnterBackgroundNotification must REBUILD the timer (background interval), not cancel-and-leave-nil. HelpSpot 17865."
+    )
+  }
+
+  // MARK: - Test 2: didBecomeActiveNotification defers position publish
+
+  /// HelpSpot 17865 — When returning to foreground, immediately publishing
+  /// `audiobook.player.currentTrackPosition` races a stale cached value
+  /// against the player's resumed clock. Patrons see the slider jump forward
+  /// by the suspend duration. The fix is to rebuild the timer first, defer a
+  /// tick for the player to refresh, and only then publish the position.
+  ///
+  /// We model the "stale → fresh" race by configuring the mock player to
+  /// return its cached (stale) position on the first read, then a refreshed
+  /// position on the second read after a tick. We then assert that the FIRST
+  /// `.positionUpdated` event the manager publishes carries the REFRESHED
+  /// timestamp — i.e., the manager waited for the player to update before
+  /// publishing.
+  func testForegroundNotification_doesNotPublishStalePosition() throws {
+    let (manager, player) = try makeManager()
+
+    let firstTrack = manager.tableOfContents.allTracks.first
+    XCTAssertNotNil(firstTrack, "Test fixture must have at least one track.")
+    guard let track = firstTrack else { return }
+
+    let stalePosition = TrackPosition(track: track, timestamp: 10.0, tracks: manager.tableOfContents.tracks)
+    let freshPosition = TrackPosition(track: track, timestamp: 90.0, tracks: manager.tableOfContents.tracks)
+
+    // Player returns stale position synchronously, then flips to fresh after
+    // a main-queue tick. The notification handler must publish the FRESH one.
+    player.currentTrackPosition = stalePosition
+    DispatchQueue.main.async {
+      player.currentTrackPosition = freshPosition
+    }
+
+    var receivedTimestamps: [Double] = []
+    let received = XCTestExpectation(description: "Position published")
+    let cancellable = manager.statePublisher.sink { state in
+      if case let .positionUpdated(position) = state, let position = position {
+        receivedTimestamps.append(position.timestamp)
+        received.fulfill()
+      }
+    }
+    defer { cancellable.cancel() }
+
+    // Act: post foreground notification.
+    NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+    wait(for: [received], timeout: 2.0)
+
+    XCTAssertFalse(receivedTimestamps.isEmpty, "Expected at least one .positionUpdated.")
+    XCTAssertEqual(
+      receivedTimestamps.first,
+      freshPosition.timestamp,
+      "First published position on foreground must be the player's REFRESHED timestamp (\(freshPosition.timestamp)), not the stale cached one (\(stalePosition.timestamp)). HelpSpot 17865."
+    )
+  }
+
+  // MARK: - Test 3: nowPlayingInfo write wrapped in beginBackgroundTask
+  //
+  // The contract calls for asserting that `MPNowPlayingInfoCenter.default()
+  // .nowPlayingInfo = ...` is wrapped in a `beginBackgroundTask`/`endBackgroundTask`
+  // envelope. This toolkit target does not have a UIApplication-style shim
+  // (no protocol abstraction over `UIApplication.shared`), so introducing
+  // one would expand scope beyond the bug fix. The wrapping IS done in
+  // `updateNowPlayingInfo` per the contract, and the main-repo
+  // `NowPlayingCoordinatorBackgroundTests` cover the writer-side equivalent
+  // with an injectable seam. Marked as skip per contract guidance:
+  //   "If the toolkit doesn't already have a UIApplication shim, document
+  //    and skip this test in the toolkit — main-repo coverage compensates."
+  func testNowPlayingInfoWrite_isWrappedInBackgroundTask() throws {
+    throw XCTSkip("Skipped per contract: toolkit lacks UIApplication shim; main-repo NowPlayingCoordinatorBackgroundTests covers writer-side beginBackgroundTask discipline.")
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the Palace iOS NowPlaying / Control Center freeze when the app is backgrounded with an audiobook playing. From HelpSpot 17865 (patron Jamie Rybin):

> "The audiobook appears to continue progressing in the background, but the playback interface stops updating unless I return to the Palace app... if I switch to Mail or another app, the playback controls seem to freeze. When I reopen Palace, the progress slider suddenly jumps forward."

Hoopla works on the same phone, so the device/OS is fine — this is a Palace-side `MPNowPlayingInfoCenter` writer lifecycle bug.

## Changes — `AudiobookManager.swift`

- **`didEnterBackgroundNotification` (line 339-353)** was nilling the NowPlaying timer "for energy savings". Fix: rebuild the timer at the existing 15s `.background` cadence so the `MPNowPlayingInfoCenter.default().nowPlayingInfo` writer keeps emitting updates while the engine plays.
- **`didBecomeActiveNotification` (line 310-323)** was firing `.positionUpdated` BEFORE the timer rebuild — the publish raced a stale `currentTrackPosition` cached during suspend, causing the patron's slider to snap forward by the suspend duration. Reordered: rebuild timer first, defer position publish one tick to let the player engine refresh its position.
- **`MPNowPlayingInfoCenter.default().nowPlayingInfo = ...`** write (line ~594) wrapped in a `UIApplication.shared.beginBackgroundTask` envelope so the write survives the suspend window.

## Tests — `AudiobookManagerLifecycleTests.swift`

- `testBackgroundNotification_rebuildsTimerAtBackgroundInterval`
- `testForegroundNotification_doesNotPublishStalePosition`
- 1 documented skip (`testNowPlayingInfoWrite_isWrappedInBackgroundTask` — needs a UIApplication shim that the toolkit doesn't have; main-repo coverage compensates via the dry-stream guard in the ios-core PR)

Full toolkit suite: **100 pass / 3 pre-existing failures (verified at SHA 24e601d4) / 1 skip**.

## Cross-repo coordination

Once this merges and is tagged (suggest `2.2.1`), the ios-core PR for swarm_dfdaf7ad bumps the submodule pin and lands the companion main-repo NowPlayingCoordinator BG-path bypass + a `TPPErrorLogger` dry-stream Crashlytics guard so future regressions of this shape surface in Crashlytics instead of patron tickets.

## Test plan

- [x] `swift test` (or toolkit's standard test driver) — all new tests pass
- [x] Mutation gate not applicable here (`palace_mutate.py` is ios-core-only)
- [ ] Manual repro on physical device after Palace 3.2.0 ships: borrow audiobook → play → lock screen → wait 60s → unlock; Control Center widget responsive, no slider jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)