### PR TITLE
PP-4358: SpeedSliderSheet is the only audiobook speed surface; preset 1.25× → 1.20×

### DIFF
--- a/PalaceAudiobookToolkit/Player/Player.swift
+++ b/PalaceAudiobookToolkit/Player/Player.swift
@@ -47,9 +47,14 @@ public enum PlaybackRate: Int, CaseIterable {
     Float(rate.rawValue) * 0.01
   }
 
-  /// Named preset rates shown as quick-select chips in the speed picker UI
+  /// Preset rates shown as quick-select chips in the speed picker UI.
+  /// PP-4358 locks this to [0.75×, 1.0×, 1.2×, 1.5×, 2.0×]. The third
+  /// preset is `.p120` (1.20×), not `.oneAndAQuarterTime` (1.25×) — the
+  /// PP-4233 design review picked 1.2× over 1.25×. `.oneAndAQuarterTime`
+  /// remains a valid enum case so historic UserDefaults values (raw 125)
+  /// still decode for users who selected 1.25× before this change.
   public static let presets: [PlaybackRate] = [
-    .threeQuartersTime, .normalTime, .oneAndAQuarterTime, .oneAndAHalfTime, .doubleTime
+    .threeQuartersTime, .normalTime, .p120, .oneAndAHalfTime, .doubleTime
   ]
 
   /// All available steps in ascending order (0.75× → 2.0×)

--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -20,8 +20,6 @@ public struct AudiobookPlayerView: View {
   @ObservedObject var playbackModel: AudiobookPlaybackModel
   @ObservedObject private var showToast = BoolWithDelay(delay: 3)
 
-  private let useIncrementalSpeedSlider: Bool
-
   @State private var showPlaybackSpeed = false
   @State private var showSleepTimer = false
   @State private var isInBackground = false
@@ -30,9 +28,8 @@ public struct AudiobookPlayerView: View {
   @State private var screenSize: CGSize = UIScreen.main.bounds.size
   @State private var loadingTimedOut = false
 
-  public init(model: AudiobookPlaybackModel, useIncrementalSpeedSlider: Bool = false) {
+  public init(model: AudiobookPlaybackModel) {
     playbackModel = model
-    self.useIncrementalSpeedSlider = useIncrementalSpeedSlider
     setupBackgroundStateHandling()
   }
   
@@ -519,9 +516,7 @@ public struct AudiobookPlayerView: View {
       }
       .modifier(SpeedPickerModifier(
         isPresented: $showPlaybackSpeed,
-        useSlider: useIncrementalSpeedSlider,
-        playbackRateBinding: playbackRateBinding,
-        legacyButtons: playbackRateButtons
+        playbackRateBinding: playbackRateBinding
       ))
       .accessibilityLabel(Text("Playback speed: \(playbackRateText)"))
 
@@ -667,17 +662,6 @@ public struct AudiobookPlayerView: View {
     )
   }
 
-  private var playbackRateButtons: [ActionSheet.Button] {
-    var buttons = PlaybackRate.presets.map { rate in
-      ActionSheet.Button.default(
-        Text(HumanReadablePlaybackRate(rate: rate).value),
-        action: { playbackModel.setPlaybackRate(rate) }
-      )
-    }
-    buttons.append(.cancel())
-    return buttons
-  }
-
   private var sleepTimerButtons: [ActionSheet.Button] {
     var buttons = [ActionSheet.Button]()
     for sleepTimer in SleepTimerTriggerAt.allCases {
@@ -724,7 +708,6 @@ private extension AudiobookPlayerView {
       )
     )
     playbackModel = AudiobookPlaybackModel(audiobookManager: audiobookManager)
-    useIncrementalSpeedSlider = false
   }
 }
 

--- a/PalaceAudiobookToolkit/UI/SpeedSliderSheet.swift
+++ b/PalaceAudiobookToolkit/UI/SpeedSliderSheet.swift
@@ -222,34 +222,23 @@ struct SpeedSliderSheet: View {
 
 // MARK: - SpeedPickerModifier
 
-/// Routes the speed-picker presentation to either the stepped slider sheet
-/// or the legacy action sheet depending on `useSlider`.
+/// Presents the audiobook playback-speed bottom sheet. PP-4358 made this
+/// the only speed-control surface in the player — the previous legacy
+/// ActionSheet path and the `useSlider` toggle have been removed.
 struct SpeedPickerModifier: ViewModifier {
   @Binding var isPresented: Bool
-  let useSlider: Bool
   let playbackRateBinding: Binding<PlaybackRate>
-  let legacyButtons: [ActionSheet.Button]
 
   func body(content: Content) -> some View {
-    if useSlider {
-      content
-        .sheet(isPresented: $isPresented) {
-          SpeedSliderSheet(
-            playbackRate: playbackRateBinding,
-            onDismiss: { isPresented = false }
-          )
-          .presentationDetents([.height(260)])
-          .presentationDragIndicator(.hidden)
-        }
-    } else {
-      content
-        .actionSheet(isPresented: $isPresented) {
-          ActionSheet(
-            title: Text(Strings.AudiobookPlayerViewController.playbackSpeed),
-            buttons: legacyButtons
-          )
-        }
-    }
+    content
+      .sheet(isPresented: $isPresented) {
+        SpeedSliderSheet(
+          playbackRate: playbackRateBinding,
+          onDismiss: { isPresented = false }
+        )
+        .presentationDetents([.height(260)])
+        .presentationDragIndicator(.hidden)
+      }
   }
 }
 


### PR DESCRIPTION
## Summary
- `PlaybackRate.presets` now `[0.75×, 1.0×, 1.2×, 1.5×, 2.0×]` — design-approved (PP-4358) replacement of the PP-4233 prototype's 1.25× preset with 1.20× (`.p120`). The enum case `.oneAndAQuarterTime = 125` is **retained** so users with 1.25× saved in `UserDefaults["playback_rate"]` keep their saved rate, and `MPRemoteCommandCenter.changePlaybackRateCommand` still decodes host-supplied 1.25 rates correctly via `PlaybackRate(rawValue:)`.
- `AudiobookPlayerView` drops `useIncrementalSpeedSlider: Bool` from its public init (the parameter no longer has a use; the sheet is the only path). The legacy `playbackRateButtons` ActionSheet builder is deleted.
- `SpeedPickerModifier` collapsed to a thin sheet-presenter — the `useSlider` / `legacyButtons:` branch is gone.

Palace-side counterpart: ThePalaceProject/ios-core#TBD (this branch is the submodule pin for that PR).

## Test plan
- [ ] Unit tests (in Palace): `PalaceTests/PlaybackRateTests` covers the new preset list with three independent locks — array identity, multipliers (Float), and an explicit "must not contain 1.25×" guard. 16/16 pass.
- [ ] Open the audiobook player on a sim with a downloaded audiobook → tap the speed chip → confirm the bottom sheet opens (no legacy action sheet).
- [ ] Drag the slider 0.75× → 2.0× and confirm continuous adjustment, audible speed change, no glitches.
- [ ] Tap each preset chip (0.75 / 1.0 / 1.2 / 1.5 / 2.0) → speed value updates live; preset chip highlights.
- [ ] Tap +/- at the 0.75× and 2.0× boundaries → buttons grey out at the bound, no over-range.
- [ ] Force-quit + relaunch + reopen the same book → selected speed persists.
- [ ] Borrow a second audiobook, open it → previous speed selection carries over.
- [ ] VoiceOver: navigate the sheet → header reads "Playback Speed, <description>"; slider exposes label/value/hint; ± labels descriptive; preset chips have `.isSelected` trait on the active one.

## References
- Story: [PP-4358](https://ebce-lyrasis.atlassian.net/browse/PP-4358)
- Prior prototype + design review: [PP-4233](https://ebce-lyrasis.atlassian.net/browse/PP-4233)
- ForgeOS changeset: cs_57e6263b (all gates passed)
- Architect review: rev_efd28414 (approved)
- QA review: rev_3c0fbd2a (approved with 3 advisory warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PP-4358]: https://ebce-lyrasis.atlassian.net/browse/PP-4358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ