### PR TITLE
Rename AudiobookSessionManager → AudiobookDownloadCoordinator

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7B78545B204DEE8500F6589B /* AudiobookNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */; };
 		PP41560001AAAA0001AAAA01 /* AudiobookPlaybackModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */; };
 		PP17865001AAAA0001AAAA01 /* AudiobookManagerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PP17865001AAAA0001AAAA00 /* AudiobookManagerLifecycleTests.swift */; };
+		EFD1F0C3T3AAAA0001AAAA01 /* AudiobookDownloadCoordinatorRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD1F0C3T3AAAA0001AAAA00 /* AudiobookDownloadCoordinatorRenameTests.swift */; };
 		7B78545D204DEE9900F6589B /* DownloadTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */; };
 		7B7B370820211CE100030A1E /* OpenAccessDownloadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7B370720211CE100030A1E /* OpenAccessDownloadTask.swift */; };
 		7B8026A3206AB0AF00012808 /* HumanReadablePlaybackRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8026A2206AB0AF00012808 /* HumanReadablePlaybackRate.swift */; };
@@ -150,7 +151,7 @@
 		E7F9BAE82A8E7F48001697DE /* PublicConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F9BAE72A8E7F48001697DE /* PublicConstants.swift */; };
 		F0AB00012E8E500100000001 /* OpenAccessBackgroundListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E500100000002 /* OpenAccessBackgroundListener.swift */; };
 		F0AB00012E8E500100000003 /* OverdriveBackgroundListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E500100000004 /* OverdriveBackgroundListener.swift */; };
-		F0AB00012E8E500100000005 /* AudiobookSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E500100000006 /* AudiobookSessionManager.swift */; };
+		F0AB00012E8E500100000005 /* AudiobookDownloadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E500100000006 /* AudiobookDownloadCoordinator.swift */; };
 		F0AB00012E8E500100000007 /* DownloadWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E500100000008 /* DownloadWatchdog.swift */; };
 		F0AB00012E8E500100000009 /* DownloadPersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E50010000000A /* DownloadPersistenceStore.swift */; };
 		F0AB00012E8E50010000000B /* PalaceAuthTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AB00012E8E50010000000C /* PalaceAuthTokenProvider.swift */; };
@@ -199,6 +200,7 @@
 		7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookNetworkServiceTest.swift; sourceTree = "<group>"; };
 		PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookPlaybackModelTests.swift; sourceTree = "<group>"; };
 		PP17865001AAAA0001AAAA00 /* AudiobookManagerLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookManagerLifecycleTests.swift; sourceTree = "<group>"; };
+		EFD1F0C3T3AAAA0001AAAA00 /* AudiobookDownloadCoordinatorRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookDownloadCoordinatorRenameTests.swift; sourceTree = "<group>"; };
 		7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadTaskMock.swift; sourceTree = "<group>"; };
 		7B7B370720211CE100030A1E /* OpenAccessDownloadTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAccessDownloadTask.swift; sourceTree = "<group>"; };
 		7B8026A2206AB0AF00012808 /* HumanReadablePlaybackRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HumanReadablePlaybackRate.swift; sourceTree = "<group>"; };
@@ -312,7 +314,7 @@
 		E7F9BAE72A8E7F48001697DE /* PublicConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicConstants.swift; sourceTree = "<group>"; };
 		F0AB00012E8E500100000002 /* OpenAccessBackgroundListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAccessBackgroundListener.swift; sourceTree = "<group>"; };
 		F0AB00012E8E500100000004 /* OverdriveBackgroundListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverdriveBackgroundListener.swift; sourceTree = "<group>"; };
-		F0AB00012E8E500100000006 /* AudiobookSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookSessionManager.swift; sourceTree = "<group>"; };
+		F0AB00012E8E500100000006 /* AudiobookDownloadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookDownloadCoordinator.swift; sourceTree = "<group>"; };
 		F0AB00012E8E500100000008 /* DownloadWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadWatchdog.swift; sourceTree = "<group>"; };
 		F0AB00012E8E50010000000A /* DownloadPersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadPersistenceStore.swift; sourceTree = "<group>"; };
 		F0AB00012E8E50010000000C /* PalaceAuthTokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PalaceAuthTokenProvider.swift; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				7B78545A204DEE8500F6589B /* AudiobookNetworkServiceTest.swift */,
 				PP41560001AAAA0001AAAA00 /* AudiobookPlaybackModelTests.swift */,
 				PP17865001AAAA0001AAAA00 /* AudiobookManagerLifecycleTests.swift */,
+				EFD1F0C3T3AAAA0001AAAA00 /* AudiobookDownloadCoordinatorRenameTests.swift */,
 				7B6C1BD320405C4D00EB791E /* CursorTests.swift */,
 				8CD8A20E243E7A0D009DA4CC /* Data+BigEndianTest.swift */,
 				7B78545C204DEE9900F6589B /* DownloadTaskMock.swift */,
@@ -449,7 +452,7 @@
 				E58FCC632BE09ED200943CEB /* FindawayAudiobook.swift */,
 				7B5441E0200EA82C0047B6C6 /* AudiobookManager.swift */,
 				7B5441DA200EA82C0047B6C6 /* AudiobookMetadata.swift */,
-				F0AB00012E8E500100000006 /* AudiobookSessionManager.swift */,
+				F0AB00012E8E500100000006 /* AudiobookDownloadCoordinator.swift */,
 				7BD8E4FB20753BC6008ED3F1 /* Bundle.swift */,
 				7B4F1B1F20361546003F047B /* Cursor.swift */,
 				A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */,
@@ -898,7 +901,7 @@
 				E79266972AB34315009901B7 /* AudiobookNavigationView.swift in Sources */,
 				F0AB00012E8E500100000001 /* OpenAccessBackgroundListener.swift in Sources */,
 				F0AB00012E8E500100000003 /* OverdriveBackgroundListener.swift in Sources */,
-				F0AB00012E8E500100000005 /* AudiobookSessionManager.swift in Sources */,
+				F0AB00012E8E500100000005 /* AudiobookDownloadCoordinator.swift in Sources */,
 				F0AB00012E8E500100000007 /* DownloadWatchdog.swift in Sources */,
 				F0AB00012E8E500100000009 /* DownloadPersistenceStore.swift in Sources */,
 				F0AB00012E8E50010000000B /* PalaceAuthTokenProvider.swift in Sources */,
@@ -915,6 +918,7 @@
 				7B78545B204DEE8500F6589B /* AudiobookNetworkServiceTest.swift in Sources */,
 				PP41560001AAAA0001AAAA01 /* AudiobookPlaybackModelTests.swift in Sources */,
 				PP17865001AAAA0001AAAA01 /* AudiobookManagerLifecycleTests.swift in Sources */,
+				EFD1F0C3T3AAAA0001AAAA01 /* AudiobookDownloadCoordinatorRenameTests.swift in Sources */,
 				7B78545D204DEE9900F6589B /* DownloadTaskMock.swift in Sources */,
 				E5B05DAA2BA4DB4500686897 /* TableOfContentsTests.swift in Sources */,
 				8C3CDB042422AB060020FC0B /* JSONUtilsTest.swift in Sources */,

--- a/PalaceAudiobookToolkit/Core/AudiobookDownloadCoordinator.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookDownloadCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  AudiobookSessionManager.swift
+//  AudiobookDownloadCoordinator.swift
 //  PalaceAudiobookToolkit
 //
 //  Copyright © 2026 The Palace Project. All rights reserved.
@@ -11,11 +11,11 @@ import Combine
 /// Singleton manager for audiobook download sessions.
 /// Persists across audiobook opens to maintain download state and handle
 /// background session reconnection.
-public final class AudiobookSessionManager {
+public final class AudiobookDownloadCoordinator {
   
   // MARK: - Singleton
   
-  public static let shared = AudiobookSessionManager()
+  public static let shared = AudiobookDownloadCoordinator()
   
   // MARK: - Properties
   
@@ -65,7 +65,7 @@ public final class AudiobookSessionManager {
   // MARK: - Initialization
   
   private init() {
-    ATLog(.debug, "AudiobookSessionManager: Initialized")
+    ATLog(.debug, "AudiobookDownloadCoordinator: Initialized")
     loadPersistedState()
   }
   
@@ -80,7 +80,7 @@ public final class AudiobookSessionManager {
   public func registerBackgroundCompletionHandler(_ handler: @escaping () -> Void, forSessionIdentifier identifier: String) {
     queue.async(flags: .barrier) { [weak self] in
       self?.backgroundCompletionHandlers[identifier] = handler
-      ATLog(.debug, "AudiobookSessionManager: Registered completion handler for session: \(identifier)")
+      ATLog(.debug, "AudiobookDownloadCoordinator: Registered completion handler for session: \(identifier)")
     }
   }
   
@@ -91,12 +91,12 @@ public final class AudiobookSessionManager {
   public func callCompletionHandler(forSessionIdentifier identifier: String) {
     queue.async(flags: .barrier) { [weak self] in
       guard let handler = self?.backgroundCompletionHandlers.removeValue(forKey: identifier) else {
-        ATLog(.warn, "AudiobookSessionManager: No completion handler found for session: \(identifier)")
+        ATLog(.warn, "AudiobookDownloadCoordinator: No completion handler found for session: \(identifier)")
         return
       }
       
       DispatchQueue.main.async {
-        ATLog(.info, "AudiobookSessionManager: Calling completion handler for session: \(identifier)")
+        ATLog(.info, "AudiobookDownloadCoordinator: Calling completion handler for session: \(identifier)")
         handler()
       }
       
@@ -113,7 +113,7 @@ public final class AudiobookSessionManager {
   public func storeReconnectedSession(_ session: URLSession, forIdentifier identifier: String) {
     queue.async(flags: .barrier) { [weak self] in
       self?.reconnectedSessions[identifier] = session
-      ATLog(.debug, "AudiobookSessionManager: Stored reconnected session: \(identifier)")
+      ATLog(.debug, "AudiobookDownloadCoordinator: Stored reconnected session: \(identifier)")
     }
     
     downloadStatePublisher.send(.sessionReconnected(sessionIdentifier: identifier))
@@ -161,7 +161,7 @@ public final class AudiobookSessionManager {
           downloadInfo.progress = 1.0
           self.activeDownloads[sessionIdentifier] = downloadInfo
           
-          ATLog(.info, "AudiobookSessionManager: Download completed and moved to: \(destinationURL.path)")
+          ATLog(.info, "AudiobookDownloadCoordinator: Download completed and moved to: \(destinationURL.path)")
           
           DispatchQueue.main.async {
             self.downloadStatePublisher.send(.downloadCompleted(sessionIdentifier: sessionIdentifier, fileURL: destinationURL))
@@ -171,7 +171,7 @@ public final class AudiobookSessionManager {
           self.persistState()
           
         } catch {
-          ATLog(.error, "AudiobookSessionManager: Failed to move downloaded file: \(error.localizedDescription)")
+          ATLog(.error, "AudiobookDownloadCoordinator: Failed to move downloaded file: \(error.localizedDescription)")
           downloadInfo.state = .failed
           self.activeDownloads[sessionIdentifier] = downloadInfo
           
@@ -180,7 +180,7 @@ public final class AudiobookSessionManager {
           }
         }
       } else {
-        ATLog(.warn, "AudiobookSessionManager: No download info found for session: \(sessionIdentifier)")
+        ATLog(.warn, "AudiobookDownloadCoordinator: No download info found for session: \(sessionIdentifier)")
         
         // Still notify about the completion
         DispatchQueue.main.async {
@@ -205,7 +205,7 @@ public final class AudiobookSessionManager {
         self.persistState()
       }
       
-      ATLog(.error, "AudiobookSessionManager: Download failed for session \(sessionIdentifier): \(error.localizedDescription)")
+      ATLog(.error, "AudiobookDownloadCoordinator: Download failed for session \(sessionIdentifier): \(error.localizedDescription)")
       
       DispatchQueue.main.async {
         self.downloadStatePublisher.send(.downloadFailed(sessionIdentifier: sessionIdentifier, error: error))
@@ -243,7 +243,7 @@ public final class AudiobookSessionManager {
       self?.activeDownloads[sessionIdentifier] = downloadInfo
       self?.persistState()
       
-      ATLog(.debug, "AudiobookSessionManager: Registered active download for session: \(sessionIdentifier)")
+      ATLog(.debug, "AudiobookDownloadCoordinator: Registered active download for session: \(sessionIdentifier)")
     }
   }
   
@@ -274,7 +274,7 @@ public final class AudiobookSessionManager {
     queue.async(flags: .barrier) { [weak self] in
       self?.activeDownloads.removeValue(forKey: sessionIdentifier)
       self?.persistState()
-      ATLog(.debug, "AudiobookSessionManager: Removed active download for session: \(sessionIdentifier)")
+      ATLog(.debug, "AudiobookDownloadCoordinator: Removed active download for session: \(sessionIdentifier)")
     }
   }
   
@@ -312,7 +312,7 @@ public final class AudiobookSessionManager {
   /// Persists the current download state to disk.
   private func persistState() {
     guard let url = persistenceURL else {
-      ATLog(.error, "AudiobookSessionManager: Cannot get persistence URL")
+      ATLog(.error, "AudiobookDownloadCoordinator: Cannot get persistence URL")
       return
     }
     
@@ -339,9 +339,9 @@ public final class AudiobookSessionManager {
       let data = try JSONEncoder().encode(persistableDownloads)
       try data.write(to: url)
       
-      ATLog(.debug, "AudiobookSessionManager: Persisted \(activeDownloads.count) downloads to disk")
+      ATLog(.debug, "AudiobookDownloadCoordinator: Persisted \(activeDownloads.count) downloads to disk")
     } catch {
-      ATLog(.error, "AudiobookSessionManager: Failed to persist state: \(error.localizedDescription)")
+      ATLog(.error, "AudiobookDownloadCoordinator: Failed to persist state: \(error.localizedDescription)")
     }
   }
   
@@ -374,9 +374,9 @@ public final class AudiobookSessionManager {
         )
       }
       
-      ATLog(.info, "AudiobookSessionManager: Loaded \(activeDownloads.count) persisted downloads")
+      ATLog(.info, "AudiobookDownloadCoordinator: Loaded \(activeDownloads.count) persisted downloads")
     } catch {
-      ATLog(.debug, "AudiobookSessionManager: No persisted state found or failed to load: \(error.localizedDescription)")
+      ATLog(.debug, "AudiobookDownloadCoordinator: No persisted state found or failed to load: \(error.localizedDescription)")
     }
   }
   
@@ -391,7 +391,7 @@ public final class AudiobookSessionManager {
         try? FileManager.default.removeItem(at: url)
       }
       
-      ATLog(.info, "AudiobookSessionManager: Cleared all state")
+      ATLog(.info, "AudiobookDownloadCoordinator: Cleared all state")
     }
   }
   
@@ -401,7 +401,7 @@ public final class AudiobookSessionManager {
   public static func migrateDownloadsFromCaches() {
     OpenAccessDownloadTask.migrateFromCachesIfNeeded()
     OverdriveDownloadTask.migrateFromCachesIfNeeded()
-    ATLog(.info, "AudiobookSessionManager: Completed download migration check")
+    ATLog(.info, "AudiobookDownloadCoordinator: Completed download migration check")
   }
 }
 

--- a/PalaceAudiobookToolkit/Player/Helpers/OpenAccessBackgroundListener.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/OpenAccessBackgroundListener.swift
@@ -44,7 +44,7 @@ public class OpenAccessBackgroundListener: AudiobookLifecycleListener {
     ATLog(.info, "OpenAccessBackgroundListener: Handling background session: \(identifier)")
     
     // Register the completion handler with the session manager
-    AudiobookSessionManager.shared.registerBackgroundCompletionHandler(
+    AudiobookDownloadCoordinator.shared.registerBackgroundCompletionHandler(
       completionHandler,
       forSessionIdentifier: identifier
     )
@@ -66,7 +66,7 @@ public class OpenAccessBackgroundListener: AudiobookLifecycleListener {
     let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     
     // Store the session so it's not deallocated
-    AudiobookSessionManager.shared.storeReconnectedSession(session, forIdentifier: identifier)
+    AudiobookDownloadCoordinator.shared.storeReconnectedSession(session, forIdentifier: identifier)
     
     ATLog(.debug, "OpenAccessBackgroundListener: Reconnected to background session: \(identifier)")
   }
@@ -88,7 +88,7 @@ final class BackgroundSessionReconnectDelegate: NSObject, URLSessionDelegate, UR
     ATLog(.info, "BackgroundSessionReconnectDelegate: Session finished events: \(sessionIdentifier)")
     
     // Call the completion handler that iOS is waiting for
-    AudiobookSessionManager.shared.callCompletionHandler(forSessionIdentifier: sessionIdentifier)
+    AudiobookDownloadCoordinator.shared.callCompletionHandler(forSessionIdentifier: sessionIdentifier)
   }
   
   // MARK: - URLSessionDownloadDelegate
@@ -104,7 +104,7 @@ final class BackgroundSessionReconnectDelegate: NSObject, URLSessionDelegate, UR
     }
     
     // Notify the session manager about the completed download
-    AudiobookSessionManager.shared.handleBackgroundDownloadCompletion(
+    AudiobookDownloadCoordinator.shared.handleBackgroundDownloadCompletion(
       sessionIdentifier: sessionIdentifier,
       downloadedFileURL: location,
       originalURL: originalURL
@@ -114,7 +114,7 @@ final class BackgroundSessionReconnectDelegate: NSObject, URLSessionDelegate, UR
   func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     if let error = error {
       ATLog(.error, "BackgroundSessionReconnectDelegate: Task completed with error: \(error.localizedDescription)")
-      AudiobookSessionManager.shared.handleBackgroundDownloadError(
+      AudiobookDownloadCoordinator.shared.handleBackgroundDownloadError(
         sessionIdentifier: sessionIdentifier,
         error: error
       )

--- a/PalaceAudiobookToolkit/Player/Helpers/OverdriveBackgroundListener.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/OverdriveBackgroundListener.swift
@@ -44,7 +44,7 @@ public class OverdriveBackgroundListener: AudiobookLifecycleListener {
     ATLog(.info, "OverdriveBackgroundListener: Handling background session: \(identifier)")
     
     // Register the completion handler with the session manager
-    AudiobookSessionManager.shared.registerBackgroundCompletionHandler(
+    AudiobookDownloadCoordinator.shared.registerBackgroundCompletionHandler(
       completionHandler,
       forSessionIdentifier: identifier
     )
@@ -66,7 +66,7 @@ public class OverdriveBackgroundListener: AudiobookLifecycleListener {
     let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     
     // Store the session so it's not deallocated
-    AudiobookSessionManager.shared.storeReconnectedSession(session, forIdentifier: identifier)
+    AudiobookDownloadCoordinator.shared.storeReconnectedSession(session, forIdentifier: identifier)
     
     ATLog(.debug, "OverdriveBackgroundListener: Reconnected to background session: \(identifier)")
   }

--- a/PalaceAudiobookToolkitTests/AudiobookDownloadCoordinatorRenameTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookDownloadCoordinatorRenameTests.swift
@@ -1,0 +1,68 @@
+//
+//  AudiobookDownloadCoordinatorRenameTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  Pins the `AudiobookSessionManager` -> `AudiobookDownloadCoordinator` rename
+//  (swarm_efd1f0c3 / T3) against an accidental revert.
+//
+//  The rename itself is enforced by the compiler -- every consumer
+//  (`OpenAccessBackgroundListener`, `OverdriveBackgroundListener`) is updated
+//  atomically, so a failing build IS the regression gate. This file adds one
+//  behavioral sanity test that exercises the renamed type's real logic
+//  (register -> query by bookID round-trip), so a future refactor that
+//  silently breaks `activeDownloads(forBookID:)` is caught here.
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+final class AudiobookDownloadCoordinatorRenameTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    AudiobookDownloadCoordinator.shared.clearAllState()
+  }
+
+  override func tearDown() {
+    AudiobookDownloadCoordinator.shared.clearAllState()
+    super.tearDown()
+  }
+
+  /// Registers two downloads under the same bookID and asserts
+  /// `activeDownloads(forBookID:)` returns both -- proves the renamed type's
+  /// dictionary store + filter path still works end-to-end after the rename.
+  func testRegisterActiveDownload_thenQueryByBookID_returnsRegisteredEntries() {
+    let bookID = "book-T3-rename"
+    let session1 = "session-1"
+    let session2 = "session-2"
+    let url = URL(string: "https://example.com/chapter.mp3")!
+    let dest = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("dest.mp3")
+
+    AudiobookDownloadCoordinator.shared.registerActiveDownload(
+      sessionIdentifier: session1,
+      bookID: bookID,
+      trackKey: "track-1",
+      originalURL: url,
+      localDestination: dest
+    )
+    AudiobookDownloadCoordinator.shared.registerActiveDownload(
+      sessionIdentifier: session2,
+      bookID: bookID,
+      trackKey: "track-2",
+      originalURL: url,
+      localDestination: dest
+    )
+
+    // The register path is dispatched via a barrier on a private serial queue.
+    // A sync read on `activeDownloads(forBookID:)` flushes pending barrier
+    // writes, so this query reflects both registrations.
+    let downloads = AudiobookDownloadCoordinator.shared.activeDownloads(forBookID: bookID)
+
+    XCTAssertEqual(downloads.count, 2)
+    XCTAssertEqual(Set(downloads.map(\.sessionIdentifier)), [session1, session2])
+    XCTAssertEqual(Set(downloads.map(\.trackKey)), ["track-1", "track-2"])
+    XCTAssertTrue(downloads.allSatisfy { $0.bookID == bookID })
+  }
+}


### PR DESCRIPTION
## Summary

Pure rename: `AudiobookSessionManager` → `AudiobookDownloadCoordinator`.

The class is a process-wide singleton that coordinates `URLSession`
background downloads — not playback sessions. The old name was
misleading on its own and collides with a distinct Palace-side
`AudiobookSessionManager` introduced separately. Renaming clarifies
intent and unblocks downstream work.

### What changed

- `git mv` on the source file preserves history.
- Class name, `.shared` accessor, doc comment, and the type-prefixed
  `ATLog` strings updated inside the renamed file.
- Two internal consumers updated atomically:
  - `Player/Helpers/OpenAccessBackgroundListener.swift` (5 call sites)
  - `Player/Helpers/OverdriveBackgroundListener.swift` (2 call sites)
- Four `project.pbxproj` references migrated (build file, file ref,
  group membership, sources build phase).
- One behavioral sanity test
  (`AudiobookDownloadCoordinatorRenameTests`) exercises a real
  `registerActiveDownload(...) → activeDownloads(forBookID:)` round-trip
  on the renamed type. The rename's structural correctness is enforced
  by the compiler; this test guards against a silent revert that
  preserves the type name but breaks the dictionary store.

### Public surface preserved

`.shared`, all 12 public methods (`registerBackgroundCompletionHandler`,
`callCompletionHandler`, `storeReconnectedSession`,
`handleBackgroundDownloadCompletion`, `handleBackgroundDownloadError`,
`registerActiveDownload`, `updateDownloadProgress`,
`removeActiveDownload`, `activeDownloads(forBookID:)`,
`downloadInfo(forSessionIdentifier:)`, `clearAllState`,
`migrateDownloadsFromCaches`), public types (`DownloadInfo`,
`AudiobookDownloadEvent`, `DownloadInfo.DownloadState`), and
`downloadStatePublisher` are all unchanged.

### Why `.shared` stays

iOS delivers `URLSession` background-session completion via a
process-wide `AppDelegate`/`SceneDelegate` handler. Binding the
coordinator to an instance would force AppDelegate-side wiring across
every consumer app — out of scope for this PR.

### Why no deprecated typealias

A repo-wide grep confirmed zero external callers of the old name. The
two internal consumers are updated atomically in this PR. A
`@available(*, deprecated, renamed:)` alias would persist the
misleading name for no migration benefit.

## Test plan

- [x] Production target compiles: `xcodebuild ... build` succeeds (the
      compiler enforces the rename across every reference).
- [x] Renamed-class sanity test compiles and is wired into the test
      bundle (`AudiobookDownloadCoordinatorRenameTests` builds; the
      method exercises real dictionary-store logic on the renamed
      type, not a tautology).
- [x] `git log --follow` on `AudiobookDownloadCoordinator.swift`
      resolves to the pre-rename history, confirming `git mv`
      preserved provenance.
- [ ] Toolkit consumer (Palace iOS) builds + tests pass after submodule
      bump (verified by the orchestrator in the integration phase of
      swarm `swarm_efd1f0c3`).

## Pre-existing failure noted (not introduced by this PR)

`PalaceAudiobookToolkitTests/ManifestDecodingTests.swift` fails to
compile against `Manifest.Metadata.FindawayDRMInformation` on
`origin/main@298f3934` (the merge-base of this branch). Reproduced by
stashing this branch's changes and building `main` directly. Out of
scope for a pure rename; should be addressed in a follow-up.