### PR TITLE
fix(player): guard LCPStreamingPlayer playCallback against double-completion

### DIFF
--- a/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
@@ -152,6 +152,15 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
   /// rebuild logic still drives playback. The async protocol override
   /// (below) bridges into this through a continuation.
   override public func playCallback(at position: TrackPosition, completion: ((Error?) -> Void)?) {
+    // Multiple async paths below — the 30s load-timeout work item, the
+    // avQueuePlayer.seek callback, the rebuild-fallback, the target-not-found
+    // branch — can all race to fire `completion`. If the timeout surfaces a
+    // failure and the underlying seek later succeeds (or vice versa), the
+    // `play(at:) async` bridge resumes its continuation twice and traps with
+    // SWIFT TASK CONTINUATION MISUSE. Wrap once at entry so every downstream
+    // call site is fire-at-most-once and thread-safe.
+    let onceCompletion = Self.makeOnceCompletion(completion)
+
     var needsRebuild = avQueuePlayer.items().isEmpty
 
     if !needsRebuild {
@@ -202,7 +211,6 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
       // rapid re-presentations stack multiple timers that all log at once.
       loadTimeoutWorkItem?.cancel()
       let timeoutPosition = position
-      let timeoutCompletion = completion
       let workItem = DispatchWorkItem { [weak self] in
         guard let self = self, !self.isLoaded else { return }
         ATLog(.warn, "LCPStreamingPlayer: Publication loading timeout — surfacing failure so caller can show an alert and release the open lock")
@@ -220,7 +228,7 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
           userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for LCP publication to load"]
         )
         self.playbackStatePublisher.send(.failed(timeoutPosition, timeoutError))
-        timeoutCompletion?(timeoutError)
+        onceCompletion(timeoutError)
       }
       loadTimeoutWorkItem = workItem
       DispatchQueue.main.asyncAfter(deadline: .now() + 30.0, execute: workItem)
@@ -246,7 +254,7 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
             // Seek failure can cause position drift. Rebuild the queue to force correct positioning
             // rather than silently continuing at the wrong position.
             rebuildPlayerQueueAndNavigate(to: position, shouldResumePlayback: true) { _ in
-              completion?(nil)
+              onceCompletion(nil)
             }
             return
           }
@@ -277,7 +285,7 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
             }
           }
 
-          completion?(nil)
+          onceCompletion(nil)
         }
         return
       }
@@ -351,10 +359,10 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
           }
         }
 
-        completion?(nil)
+        onceCompletion(nil)
       }
     } else {
-      completion?(NSError(
+      onceCompletion(NSError(
         domain: "LCPStreamingPlayer",
         code: -1,
         userInfo: [NSLocalizedDescriptionKey: "Target track not found in queue"]
@@ -449,6 +457,27 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
   }
 
   // MARK: - Helpers
+
+  /// Wraps an optional `(Error?) -> Void` completion in a thread-safe,
+  /// fire-at-most-once closure. Required because `playCallback` has multiple
+  /// racing async paths (timeout work item, seek callback, rebuild fallback)
+  /// that can each invoke the caller's completion; the upstream `play(at:)`
+  /// async bridge resumes a CheckedContinuation and traps on a second resume.
+  /// Returns a non-optional closure so call sites stay simple even when the
+  /// caller passed `nil`.
+  static func makeOnceCompletion(_ completion: ((Error?) -> Void)?) -> (Error?) -> Void {
+    let lock = NSLock()
+    var fired = false
+    return { error in
+      lock.lock()
+      let shouldFire = !fired
+      fired = true
+      lock.unlock()
+      if shouldFire {
+        completion?(error)
+      }
+    }
+  }
 
   private func safeTimestamp(for position: TrackPosition) -> TimeInterval {
     let duration = position.track.duration

--- a/PalaceAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -293,9 +293,25 @@ class OpenAccessPlayer: NSObject, Player {
   /// Async protocol surface — bridges to the internal callback implementation
   /// via `withCheckedThrowingContinuation`. Throws when the underlying seek
   /// fails (callback would have surfaced `Error`).
+  ///
+  /// Defensive: subclass overrides of `playCallback` historically had races
+  /// (timeout work item + late seek-success in LCPStreamingPlayer) that fired
+  /// the completion twice and trapped on second-resume. Guard the
+  /// continuation here so any future regression in any subclass logs instead
+  /// of crashing users.
   func play(at position: TrackPosition) async throws {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      let lock = NSLock()
+      var resumed = false
       playCallback(at: position) { error in
+        lock.lock()
+        let shouldResume = !resumed
+        resumed = true
+        lock.unlock()
+        guard shouldResume else {
+          ATLog(.warn, "OpenAccessPlayer.play(at:): playCallback completion fired more than once; ignoring duplicate (error: \(error.map { "\($0)" } ?? "nil"))")
+          return
+        }
         if let error = error {
           continuation.resume(throwing: error)
         } else {

--- a/PalaceAudiobookToolkitTests/LCPStreamingPlayerAsyncContractTests.swift
+++ b/PalaceAudiobookToolkitTests/LCPStreamingPlayerAsyncContractTests.swift
@@ -148,6 +148,133 @@ final class LCPStreamingPlayerAsyncContractTests: XCTestCase {
                    "Position must be passed unchanged to playCallback")
   }
 
+  /// Regression for the 3.2.0 "publication loading timeout → seek-late-success"
+  /// race: `LCPStreamingPlayer.playCallback` has multiple racing async paths
+  /// (30s timeout work item, avQueuePlayer.seek callback, rebuild fallback)
+  /// that all invoke the caller's `completion`. Before the fix, a timeout
+  /// would surface failure, and the underlying seek's late success would
+  /// invoke the same completion again — double-resuming the `play(at:)`
+  /// async continuation and trapping with SWIFT TASK CONTINUATION MISUSE.
+  ///
+  /// This test simulates that race by stubbing `playCallback` to fire its
+  /// completion twice (first with the timeout error, then with success).
+  /// The async surface MUST resolve exactly once. The bridge-level
+  /// once-guard in OpenAccessPlayer.play(at:) is what holds the line for
+  /// any future subclass regression; this test pins that contract.
+  func testPlayAt_asyncSurface_doesNotDoubleResume_whenPlayCallbackFiresTwice() async {
+    final class DoubleFireStub: LCPStreamingPlayer {
+      var firstError: Error?
+      var secondError: Error?
+
+      override func configurePlayer() {}
+      override func addPlayerObservers() {}
+      override func removePlayerObservers() {}
+
+      override public func playCallback(at position: TrackPosition, completion: ((Error?) -> Void)?) {
+        // First call: simulate the 30s timeout surfacing failure.
+        completion?(firstError)
+        // Second call: simulate the underlying seek eventually completing
+        // — historically this resumed the continuation a second time.
+        completion?(secondError)
+      }
+    }
+
+    let player = DoubleFireStub(tableOfContents: toc, drmDecryptor: nil)
+    player.firstError = NSError(
+      domain: "LCPStreamingPlayer",
+      code: -1,
+      userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for LCP publication to load"]
+    )
+    player.secondError = nil // late success after the timeout already fired
+
+    // If the bridge double-resumed, this `try await` would trap the test
+    // process with SWIFT TASK CONTINUATION MISUSE. Surviving the await
+    // (regardless of throw/non-throw outcome) is the contract.
+    let target = TrackPosition(track: firstTrack, timestamp: 0, tracks: toc.tracks)
+    do {
+      try await player.play(at: target)
+      // The first resume was the timeout error — the bridge should propagate
+      // that as a throw. If it returned success, the once-guard fired in the
+      // wrong direction (would mean the timeout error was swallowed).
+      XCTFail("Expected first-fire timeout error to propagate as throw")
+    } catch let error as NSError {
+      XCTAssertEqual(error.domain, "LCPStreamingPlayer",
+                     "First completion fire (timeout error) must be the one that resolves the continuation")
+      XCTAssertEqual(error.code, -1)
+    }
+
+    // Give the runtime a beat to surface a double-resume trap if the guard
+    // failed — XCTest reports continuation-misuse on the next runloop tick.
+    try? await Task.sleep(nanoseconds: 50_000_000)
+  }
+
+  /// Inverse of the above: when the late "success" fires FIRST and the
+  /// timeout fires second (e.g. seek completes at 29.9s and the timeout
+  /// at 30s sneaks in before isLoaded propagates), the async surface must
+  /// still resolve exactly once — and with the first outcome.
+  func testPlayAt_asyncSurface_doesNotDoubleResume_whenSuccessThenTimeout() async {
+    final class DoubleFireStub: LCPStreamingPlayer {
+      override func configurePlayer() {}
+      override func addPlayerObservers() {}
+      override func removePlayerObservers() {}
+
+      override public func playCallback(at position: TrackPosition, completion: ((Error?) -> Void)?) {
+        completion?(nil) // seek succeeded
+        completion?(NSError(domain: "LCPStreamingPlayer", code: -1)) // stale timeout
+      }
+    }
+
+    let player = DoubleFireStub(tableOfContents: toc, drmDecryptor: nil)
+    let target = TrackPosition(track: firstTrack, timestamp: 0, tracks: toc.tracks)
+    do {
+      try await player.play(at: target)
+    } catch {
+      XCTFail("Expected first-fire success to win, but bridge threw \(error)")
+    }
+    try? await Task.sleep(nanoseconds: 50_000_000)
+  }
+
+  // MARK: - makeOnceCompletion helper
+
+  /// Unit-level pin for the once-guard helper used inside
+  /// `LCPStreamingPlayer.playCallback` to defang the timeout/seek race
+  /// at its source. The bridge-level guard in OpenAccessPlayer is a
+  /// safety net; THIS guard ensures the seek callback's playback
+  /// side-effects (e.g. mute toggles, isLoaded flips, started events)
+  /// aren't accompanied by a spurious second completion.
+  func testMakeOnceCompletion_firesAtMostOnceAcrossThreads() {
+    let invocationCount = NSLock()
+    var calls: [Error?] = []
+    let wrapped = LCPStreamingPlayer.makeOnceCompletion { error in
+      invocationCount.lock()
+      calls.append(error)
+      invocationCount.unlock()
+    }
+
+    let group = DispatchGroup()
+    for i in 0..<32 {
+      group.enter()
+      DispatchQueue.global().async {
+        wrapped(i == 0 ? nil : NSError(domain: "test", code: i))
+        group.leave()
+      }
+    }
+    group.wait()
+
+    XCTAssertEqual(calls.count, 1,
+                   "makeOnceCompletion must collapse concurrent invocations to a single underlying call")
+  }
+
+  /// Nil-completion case: the wrapped closure must still be safe to call
+  /// (no trap, no allocation surprises). Mutant: a `completion!` in the
+  /// wrapper would crash here.
+  func testMakeOnceCompletion_safeWhenSourceCompletionIsNil() {
+    let wrapped = LCPStreamingPlayer.makeOnceCompletion(nil)
+    wrapped(nil)
+    wrapped(NSError(domain: "test", code: 1))
+    // Reaching here without crashing IS the assertion.
+  }
+
   /// When the LCP override's playCallback yields an error, the async
   /// surface must throw. Mutant: swallowing the error in the
   /// continuation would let failed LCP loads silently no-op.


### PR DESCRIPTION
## Summary

Fixes a `SWIFT TASK CONTINUATION MISUSE` crash in `LCPStreamingPlayer.play(at:)` that reproduces under library-swap stress in Palace iOS 3.2.0:

```
LCPStreamingPlayer: Publication loading timeout — surfacing failure so caller can show an alert and release the open lock
_Concurrency/CheckedContinuation.swift:196: Fatal error: SWIFT TASK CONTINUATION MISUSE: play(at:) tried to resume its continuation more than once,
throwing Error Domain=LCPStreamingPlayer Code=-1 "Timed out waiting for LCP publication to load"
```

### Root cause

`LCPStreamingPlayer.playCallback(at:completion:)` runs two concurrent async paths:

1. A **30s load-timeout** `DispatchWorkItem` that calls `completion(timeoutError)` when the LCP resource loader hasn't surfaced `isLoaded` in time (added to make the "Audiobook Unavailable" alert work + release the open lock).
2. An `avQueuePlayer.seek` completion that calls `completion(nil)` when the seek lands.

If the timeout wins (the seek is stuck on a stale resource loader from a prior library), the failure surfaces correctly. But the seek's completion callback fires later when the loader eventually returns — invoking the same `completion` a **second** time. `OpenAccessPlayer.play(at:) async throws` wraps this in `withCheckedThrowingContinuation`, so the second call resumes the continuation a second time → trap.

### When it was introduced

Latent two-step regression:

| Date | PR | What changed |
|------|-----|--------------|
| 2026-04-22 | #167 | Added the 30s timeout that calls `completion(timeoutError)`. Cancel-on-success only fires inside a deferred `asyncAfter` (and only in the fast path). Double-completion was possible but inert because all callers were callback-shaped. |
| 2026-05-22 | #177 | Migrated `Player` protocol to async/await. New `play(at:) async throws` wraps `playCallback` in a `CheckedContinuation`. **This is what turned the dormant double-call into a hard crash.** |

The crash window only opens when the resource loader hangs >30s AND the seek eventually completes — reproduces reliably under fast library swapping where stale loaders haven't released.

### Fix

- **Source fix:** `LCPStreamingPlayer.playCallback` wraps the incoming completion in a thread-safe (`NSLock`-backed) once-guard at function entry. All five call sites — timeout work item, fast-path seek success, fast-path seek-failure rebuild fallback, rebuild seek success, target-not-found branch — route through the wrapped closure.
- **Bridge-level safety net:** `OpenAccessPlayer.play(at:)` wraps the `withCheckedThrowingContinuation` in its own once-guard with `ATLog(.warn, …)` on the duplicate-fire path. Protects against any future regression in any `playCallback` override (OpenAccess, Findaway, LCP) — duplicate completions log instead of crash users.

### Test plan

- [x] `LCPStreamingPlayerAsyncContractTests` — 8/8 pass, including 4 new tests:
  - `testPlayAt_asyncSurface_doesNotDoubleResume_whenPlayCallbackFiresTwice` (timeout → late success)
  - `testPlayAt_asyncSurface_doesNotDoubleResume_whenSuccessThenTimeout` (success → stale timeout)
  - `testMakeOnceCompletion_firesAtMostOnceAcrossThreads` (32-thread concurrent stress)
  - `testMakeOnceCompletion_safeWhenSourceCompletionIsNil` (nil-completion safety)
- [x] `AudiobookPlaybackModelTests` sanity check — 4/4 pass.
- [ ] Validate in Palace iOS regression: jump between libraries, search-and-open in A1QA with stale resource loaders pending; expect "Audiobook Unavailable" alert + clean recovery instead of crash.

### Out of scope

This PR does not address **why** the LCP resource loader can hang for 30s under library-swap stress. That's the underlying issue that the timeout exists to backstop; the timeout + alert was the user-facing recovery, and now it actually recovers cleanly instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)