### PR TITLE
PP-4340: bump Readium swift-toolkit to 3.9.0

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -1266,7 +1266,7 @@
 			repositoryURL = "https://github.com/readium/swift-toolkit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.7.0;
+				version = 3.9.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PalaceAudiobookToolkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PalaceAudiobookToolkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/readium/swift-toolkit.git",
       "state" : {
-        "revision" : "907f35b67193e53361b7c7042ff1c2dee258f743",
-        "version" : "3.7.0"
+        "revision" : "de07026e9f825a5791f27a7ac4cd6bb1a784ab8d",
+        "version" : "3.9.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "d1d6add8f277bd76992a0f7e72961a896609b707",
-        "version" : "2.9.5"
+        "revision" : "49dcadd93161f4a44b4994d3a3e8de9f085aface",
+        "version" : "2.13.5"
       }
     },
     {

--- a/PalaceAudiobookToolkit/Player/RangeResource.swift
+++ b/PalaceAudiobookToolkit/Player/RangeResource.swift
@@ -33,7 +33,10 @@ public class RangeResource: Resource {
 
       var props = ResourceProperties()
       if let len = response.contentLength {
-        props["length"] = UInt64(len)
+        // Readium 3.9.0: ResourceProperties values must be JSONValueEncodable
+        // *and* JSONValueDecodable. UInt64 is only Encodable, so store the
+        // length as Int (which conforms to both) and widen on read-back.
+        props["length"] = Int(len)
       }
       if let mt = response.mediaType {
         props.mediaType = mt
@@ -91,9 +94,10 @@ public class RangeResource: Resource {
       return cached
     }
     let props = try await properties().get()
-    guard let l = props.properties["length"] as? UInt64 else {
+    guard let lengthValue: Int = props["length"] else {
       throw NSError(domain: "NoContentLength", code: -1)
     }
+    let l = UInt64(lengthValue)
     lengthCache = l
     return l
   }


### PR DESCRIPTION
Bumps Readium swift-toolkit 3.7.0 → 3.9.0 to move in lockstep with ios-core PP-4340 (the app links one swift-toolkit version across the embedded `PalaceAudiobookToolkit.framework`, so the submodule cannot lag).

## Change
- `swift-toolkit` SPM pin 3.7.0 → 3.9.0 (pbxproj + Package.resolved)
- `RangeResource.swift`: Readium 3.9.0 made `ResourceProperties` values require `JSONValueEncodable & JSONValueDecodable`. `UInt64` is encode-only, so the content length is stored as `Int` (conforms to both) and widened to `UInt64` on read-back.

## Verification
- Builds as part of the Palace app on 3.9.0 (both `Palace` and `Palace-noDRM` targets green).
- No behavior change — `Int`/`UInt64` bridging is value-preserving for content lengths.

**Merge with a regular merge commit (not squash)** — ios-core's submodule pointer references this branch's commit SHA; squashing would orphan it and break ios-core's submodule fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)