### PR TITLE
fix: make AudiobookNavigationView public for in-app-nav TOC presentation

### DIFF
--- a/PalaceAudiobookToolkit/UI/AudiobookNavigationView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookNavigationView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 // MARK: - AudiobookNavigationView
 
-struct AudiobookNavigationView: View {
+public struct AudiobookNavigationView: View {
   typealias DisplayStrings = Strings.AudiobookTableOfContentsTableViewController
 
   enum NavigationSection: Identifiable, CaseIterable {
@@ -36,11 +36,11 @@ struct AudiobookNavigationView: View {
   @State private var isLoading: Bool = false
 
   @ObservedObject private var playback: AudiobookPlaybackModel
-  init(model: AudiobookPlaybackModel) {
+  public init(model: AudiobookPlaybackModel) {
     playback = model
   }
 
-  var body: some View {
+  public var body: some View {
     ZStack {
       VStack(spacing: 0) {
         if playback.audiobookManager.needsDownloadRetry {


### PR DESCRIPTION
## What

Makes `AudiobookNavigationView` (the Chapters + Bookmarks screen) `public` — `public struct` + `public init(model:)` + `public var body`. Visibility-only; no behavior change.

## Why

In the Palace in-app-navigation audiobook flow (`AudiobookFullPlayerCoverContainer`, behind `in_app_playback_nav_enabled`), the full player is hosted **outside** any `NavigationStack`. The toolkit's TOC button is a `.navigationBar`-placement toolbar item + `NavigationLink`, which SwiftUI only renders inside a `NavigationStack` — so the button silently disappeared and Chapters/Bookmarks became unreachable.

Rather than wrap the player in a nested `NavigationStack` (which crashes — SwiftUI `NavigationRequestObserver tried to update multiple times per frame` on back-nav), Palace now presents `AudiobookNavigationView` directly in a `fullScreenCover`. That requires the view to be `public`.

## Risk

Minimal — visibility only. The legacy push-based flow (where the player IS inside a `NavigationStack`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)