### PR TITLE
fix(toc): collapse oversubdivided / dense TOCs to one chapter per physical file

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		178707C824DA505700649567 /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178707C724DA505700649567 /* RSAUtils.swift */; };
 		19F62DA8C518E86919A8603B /* FindawayPlayerAsyncContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44273C33D2A6561243E0041A /* FindawayPlayerAsyncContractTests.swift */; };
 		21B26CD0257FBA9F00A60238 /* LCPDownloadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B26CCF257FBA9F00A60238 /* LCPDownloadTask.swift */; };
+		225086F9A461257904E5F191 /* FindawayOversubdividedTOCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA300CAAE5604D932B875266 /* FindawayOversubdividedTOCTests.swift */; };
+		3243173178F87A550EB31653 /* dune_oversubdivided_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 8E13C49FB5EE117E6C20A818 /* dune_oversubdivided_manifest.json */; };
 		51A60E3AFDF6482AB2FECA5A /* ChunkStallRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0BA890FAA749DAA0A58139 /* ChunkStallRetryTests.swift */; };
 		56E55E478FF5A2201284A576 /* FindawayDownloadEngineGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED08DDCBC8158591177047B /* FindawayDownloadEngineGate.swift */; };
 		64EF6FD2B05B1F3409967F5B /* FindawayDownloadEngineGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0873ED7E066863822184CA2A /* FindawayDownloadEngineGateTests.swift */; };
@@ -49,6 +51,7 @@
 		8CD8A20F243E7A0D009DA4CC /* Data+BigEndianTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A20E243E7A0D009DA4CC /* Data+BigEndianTest.swift */; };
 		8CF57BDA243277180053C31E /* MediaProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF57BD9243277180053C31E /* MediaProcessor.swift */; };
 		8CF57BDC2432788C0053C31E /* Data+BigEndian.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF57BDB2432788C0053C31E /* Data+BigEndian.swift */; };
+		A21FD3FA5324875CF1ED74A4 /* dune_oversubdivided_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 8E13C49FB5EE117E6C20A818 /* dune_oversubdivided_manifest.json */; };
 		A9DC9CFD220547F800D122F2 /* ErrorDescriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */; };
 		BTRF00012F1900030000001B /* BearerTokenRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BTRF00012F1900030000001A /* BearerTokenRefreshTests.swift */; };
 		C822F18BA3A94D16A7295A38 /* SpeedSliderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC08A6FDAE14519BD997FE3 /* SpeedSliderSheet.swift */; };
@@ -235,10 +238,12 @@
 		8CD8A20E243E7A0D009DA4CC /* Data+BigEndianTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+BigEndianTest.swift"; sourceTree = "<group>"; };
 		8CF57BD9243277180053C31E /* MediaProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProcessor.swift; sourceTree = "<group>"; };
 		8CF57BDB2432788C0053C31E /* Data+BigEndian.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+BigEndian.swift"; sourceTree = "<group>"; };
+		8E13C49FB5EE117E6C20A818 /* dune_oversubdivided_manifest.json */ = {isa = PBXFileReference; includeInIndex = 1; path = dune_oversubdivided_manifest.json; sourceTree = "<group>"; };
 		A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDescriptions.swift; sourceTree = "<group>"; };
 		AF0BA890FAA749DAA0A58139 /* ChunkStallRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkStallRetryTests.swift; sourceTree = "<group>"; };
 		BFC08A6FDAE14519BD997FE3 /* SpeedSliderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedSliderSheet.swift; sourceTree = "<group>"; };
 		BTRF00012F1900030000001A /* BearerTokenRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BearerTokenRefreshTests.swift; sourceTree = "<group>"; };
+		CA300CAAE5604D932B875266 /* FindawayOversubdividedTOCTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindawayOversubdividedTOCTests.swift; sourceTree = "<group>"; };
 		CC6B0E3419F97699D846679F /* LCPStreamingPlayerAsyncContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPStreamingPlayerAsyncContractTests.swift; sourceTree = "<group>"; };
 		D5A0909B2B97986500C0FF2F /* theBigFail_manifest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = theBigFail_manifest.json; sourceTree = "<group>"; };
 		E50121732BB493670049730D /* animalFarm_manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = animalFarm_manifest.json; sourceTree = "<group>"; };
@@ -428,6 +433,7 @@
 				44273C33D2A6561243E0041A /* FindawayPlayerAsyncContractTests.swift */,
 				18D85AFEE239B40FCDB164E9 /* AsyncCallSiteTests.swift */,
 				0873ED7E066863822184CA2A /* FindawayDownloadEngineGateTests.swift */,
+				CA300CAAE5604D932B875266 /* FindawayOversubdividedTOCTests.swift */,
 			);
 			path = PalaceAudiobookToolkitTests;
 			sourceTree = "<group>";
@@ -574,6 +580,7 @@
 				E5338AD02BEAB816002387E1 /* littleWomenDevotional_manifest.json */,
 				E57105E52C2CB6D200F1F033 /* endOfTheWorld_manifest.json */,
 				E5D61EF82C3C82D80054029E /* where_the_line_is_drawn_manifest.json */,
+				8E13C49FB5EE117E6C20A818 /* dune_oversubdivided_manifest.json */,
 			);
 			path = TestResources;
 			sourceTree = "<group>";
@@ -780,6 +787,7 @@
 				E52C1C4E2C00437F00D8F30B /* the_system_of_the_world_manifest.json in Resources */,
 				7B3BD9CC2011848B002C5416 /* Media.xcassets in Resources */,
 				E715993C2AA9185A000800A8 /* alice_manifest.json in Resources */,
+				3243173178F87A550EB31653 /* dune_oversubdivided_manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -805,6 +813,7 @@
 				E55470142B7C1814003447B8 /* quicksilver_manifest.json in Resources */,
 				E59D32002F184FFF0021CAE9 /* dungeon_crawler_carl_manifest.json in Resources */,
 				E59D32012F184FFF0021CAE9 /* dracula_manifest.json in Resources */,
+				A21FD3FA5324875CF1ED74A4 /* dune_oversubdivided_manifest.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -954,6 +963,7 @@
 				19F62DA8C518E86919A8603B /* FindawayPlayerAsyncContractTests.swift in Sources */,
 				CB30400D42C41EFF1F1BA8A5 /* AsyncCallSiteTests.swift in Sources */,
 				64EF6FD2B05B1F3409967F5B /* FindawayDownloadEngineGateTests.swift in Sources */,
+				225086F9A461257904E5F191 /* FindawayOversubdividedTOCTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceAudiobookToolkit/Player/Helpers/Models/AudiobookTableOfContents.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Models/AudiobookTableOfContents.swift
@@ -44,11 +44,13 @@ public struct AudiobookTableOfContents: AudiobookTableOfContentsProtocol {
       loadTocFromLinks(linksDictionary)
     }
 
+    collapseAdjacentDuplicateKeyChapters()
+
     if manifest.audiobookType != .findaway && manifest.audiobookType != .overdrive {
       calculateDurations()
       calculateEndPositions()
     }
-    
+
     // DEBUG: Dump full TOC structure for debugging
     ATLog(.debug, "AudiobookTableOfContents initialized with \(toc.count) chapters and \(tracks.count) tracks")
     for (index, chapter) in toc.enumerated() {
@@ -153,6 +155,76 @@ public struct AudiobookTableOfContents: AudiobookTableOfContentsProtocol {
         toc.append(chapter)
       }
     }
+  }
+
+  /// Repair chapter lists that don't match the physical audio files, so the
+  /// toolkit's `toc` (used by currentChapter / NowPlaying / saved-position) is the
+  /// SAME single list the UI shows. Two cases, one rule each:
+  ///
+  /// 1. Densely-subdivided TOC — many section/paragraph entries over few audio
+  ///    files (e.g. "The Martian": 41 TOC entries, 8 files). Detected by the 1.5x
+  ///    inflation threshold; collapsed to ONE chapter per physical `track.key`.
+  ///    This is the app's historical `ChapterTOCNormalizer` collapse, MOVED here
+  ///    so the toolkit and app share one implementation (no second list to drift).
+  ///
+  /// 2. Oversubdivided readingOrder — a manifest that repeats the same physical
+  ///    `(part, sequence)` / `track.key` for several chapters that all start at the
+  ///    SAME offset (Findaway "Dune", Findaway id 32884: 3 chapters all on
+  ///    findaway:1:3 @ts0). Not dense enough to trip the threshold, but still one
+  ///    playable file behind several @ts0 chapters → currentChapter / NowPlaying /
+  ///    saved-position desync ("dual numbering"; a 30s skip never crosses a
+  ///    non-existent intra-file boundary). Collapsed by dropping adjacent chapters
+  ///    that repeat the previous chapter's (track.key, start offset).
+  ///
+  /// Both keep the FIRST chapter of a group unchanged (matching the app's display).
+  /// Chapters that share a `track.key` but start at DISTINCT offsets — legitimate
+  /// multi-chapter-per-file, e.g. open-access "Dungeon Crawler Carl" (Part I @t=1,
+  /// Chapter 2 @t=3 in one MP3) — are PRESERVED: offset-distinctness is the
+  /// separator, so real navigation is never lost.
+  private mutating func collapseAdjacentDuplicateKeyChapters() {
+    guard toc.count > 1 else { return }
+    if Self.isOversubdivided(tocCount: toc.count, trackCount: tracks.tracks.count) {
+      keepFirstChapterPerTrackKey()
+    } else {
+      collapseAdjacentDuplicatePositions()
+    }
+  }
+
+  /// Dense-TOC collapse: keep one chapter per physical `track.key`.
+  private mutating func keepFirstChapterPerTrackKey() {
+    var seenKeys = Set<String>()
+    var collapsed: [Chapter] = []
+    collapsed.reserveCapacity(toc.count)
+    for chapter in toc where seenKeys.insert(chapter.position.track.key).inserted {
+      collapsed.append(chapter)
+    }
+    toc = collapsed
+  }
+
+  /// Findaway-oversubdivision collapse: drop adjacent chapters that repeat the
+  /// previous chapter's (track.key, start offset). Distinct offsets are preserved.
+  private mutating func collapseAdjacentDuplicatePositions() {
+    let epsilon = 0.5
+    var collapsed: [Chapter] = []
+    collapsed.reserveCapacity(toc.count)
+    for chapter in toc {
+      if let last = collapsed.last,
+         last.position.track.key == chapter.position.track.key,
+         abs(last.position.timestamp - chapter.position.timestamp) < epsilon {
+        continue
+      }
+      collapsed.append(chapter)
+    }
+    toc = collapsed
+  }
+
+  /// TOC oversubdivision threshold: a flat TOC with more than `trackCount * 1.5`
+  /// entries is densely subdivided into sections rather than chapters. Mirrors the
+  /// app's historical `ChapterTOCNormalizer.isOversubdivided` so the dense-collapse
+  /// behavior is identical when it moves into the toolkit (single source of truth).
+  static func isOversubdivided(tocCount: Int, trackCount: Int) -> Bool {
+    guard trackCount > 0 else { return false }
+    return Double(tocCount) > Double(trackCount) * 1.5
   }
 
   private mutating func prependForwardChapterIfNeeded() {

--- a/PalaceAudiobookToolkitTests/FindawayOversubdividedTOCTests.swift
+++ b/PalaceAudiobookToolkitTests/FindawayOversubdividedTOCTests.swift
@@ -1,0 +1,156 @@
+//
+//  FindawayOversubdividedTOCTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  Regression: 3.2.0 Findaway dual chapter-numbering on oversubdivided titles
+//  ("Dune", Findaway id 32884). Multiple short TOC chapters map to ONE physical
+//  audio file (findaway:1:3). 3.2.0 collapses the TOC app-side for DISPLAY, but the
+//  TOOLKIT still resolves currentChapter / NowPlaying / saved-position against the
+//  FULL uncollapsed list -> the chapter SHOWN disagrees with the chapter SAVED and
+//  the one NowPlaying reports (dual numbering; a 30s skip inside the file never
+//  advances the displayed chapter).
+//
+//  Invariant restored by the toolkit-side fix: the TOC is ONE collapsed list — one
+//  chapter per physical track.key — so SHOWN == SAVED == NowPlaying.
+//
+
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+final class FindawayOversubdividedTOCTests: XCTestCase {
+  private let testID = "testID"
+  private let duneKey = "urn:org.thepalaceproject:findaway:1:3"
+
+  private func loadDuneTOC() throws -> (AudiobookTableOfContents, Tracks) {
+    let manifest = try Manifest.from(
+      jsonFileName: "dune_oversubdivided_manifest",
+      bundle: Bundle(for: type(of: self))
+    )
+    let tracks = Tracks(manifest: manifest, audiobookID: testID, token: nil)
+    return (AudiobookTableOfContents(manifest: manifest, tracks: tracks), tracks)
+  }
+
+  /// RED #1 — dual-numbering root: the toolkit TOC must collapse to ONE chapter per
+  /// physical track.key (the list the UI shows), NOT one per readingOrder item.
+  /// Fixture: 5 reading-order items, 3 distinct track.keys (1:1, 1:3, 1:4).
+  func testOversubdividedFindaway_TOCCollapsesToOneChapterPerTrack() throws {
+    let (toc, _) = try loadDuneTOC()
+    XCTAssertEqual(
+      toc.toc.count, 3,
+      "Oversubdivided Findaway TOC must collapse to one chapter per physical track " +
+      "(3 distinct keys 1:1/1:3/1:4); got \(toc.toc.count). Pre-fix == 5: the toolkit " +
+      "list disagrees with the UI's collapsed list (dual numbering)."
+    )
+  }
+
+  /// RED #2 — exactly ONE TOC index maps to the oversubdivided physical track (no dual
+  /// numbering across its 3 sub-chapters).
+  func testOversubdividedFindaway_OneChapterIndexPerPhysicalTrack() throws {
+    let (toc, _) = try loadDuneTOC()
+    let indices = toc.toc.indices.filter { toc.toc[$0].position.track.key == duneKey }
+    XCTAssertEqual(
+      indices.count, 1,
+      "Exactly one TOC index must map to \(duneKey); multiple indices == dual numbering. Got \(indices)."
+    )
+  }
+
+  /// RED #3 — KEEP-FIRST: the collapsed chapter IS the first sub-chapter unchanged
+  /// (its own title + duration), matching the app's normalizedChapters. NOT a sum —
+  /// the oversubdivided sub-durations are not additive sub-ranges of one physical
+  /// file (real "Dune": Ch2's claimed 1257.874s exceeds the ~998s file).
+  func testOversubdividedFindaway_CollapsedChapterKeepsFirstSubChapter() throws {
+    let (toc, _) = try loadDuneTOC()
+    let onDune = toc.toc.filter { $0.position.track.key == duneKey }
+    XCTAssertEqual(onDune.count, 1, "Expected exactly one collapsed chapter for \(duneKey); got \(onDune.count).")
+    XCTAssertEqual(onDune.first?.title, "Chapter 2", "Collapsed chapter keeps the FIRST sub-chapter's title.")
+    XCTAssertEqual(
+      onDune.first?.duration ?? -1, 1257.874, accuracy: 0.01,
+      "Collapsed chapter keeps the FIRST sub-chapter's duration (keep-first, not sum)."
+    )
+  }
+
+  /// RED #4 — SAVED == PLAYED: a real played position inside the oversubdivided file
+  /// must resolve to a SINGLE chapter on the SAME physical track that is played, with a
+  /// single TOC index (so the app's SAVED index == the NowPlaying index). Pre-fix the
+  /// full list has 3 chapters on track 1:3, so the saved index disagrees with NowPlaying.
+  func testOversubdividedFindaway_SavedChapterMatchesPlayedTrack_singleResolution() throws {
+    let (toc, tracks) = try loadDuneTOC()
+    guard let duneTrack = tracks.track(forKey: duneKey) else {
+      return XCTFail("fixture must contain physical track \(duneKey)")
+    }
+    let played = TrackPosition(track: duneTrack, timestamp: 34.757, tracks: tracks)
+    let shown = try toc.chapter(forPosition: played)
+    XCTAssertEqual(
+      shown.position.track.key, played.track.key,
+      "Shown/saved chapter must be on the played track \(duneKey); got \(shown.position.track.key)."
+    )
+    let duneIndices = toc.toc.indices.filter { toc.toc[$0].position.track.key == duneKey }
+    XCTAssertEqual(
+      duneIndices.count, 1,
+      "Exactly one TOC index maps to the played track \(duneKey); multiple == saved/NowPlaying desync. Got \(duneIndices)."
+    )
+  }
+
+  /// NEGATIVE (PP-3518): legitimate multi-chapter-per-file with DISTINCT offsets
+  /// (open-access "Dungeon Crawler Carl": Part I @t=1 and Chapter 2 @t=3 both in
+  /// file 003) must NOT be collapsed — real navigation preserved.
+  func testDungeonCrawlerCarl_distinctOffsetChaptersNotCollapsed() throws {
+    let manifest = try Manifest.from(
+      jsonFileName: "dungeon_crawler_carl_manifest", bundle: Bundle(for: type(of: self)))
+    let tracks = Tracks(manifest: manifest, audiobookID: testID, token: nil)
+    let toc = AudiobookTableOfContents(manifest: manifest, tracks: tracks)
+    XCTAssertEqual(toc.toc.count, 7, "DCC's 7 chapters must be preserved (distinct offsets); got \(toc.toc.count).")
+    let partI = toc.toc.first { $0.title == "Part I" }
+    let chapter2 = toc.toc.first { $0.title == "Chapter 2" }
+    XCTAssertNotNil(partI, "Part I must be preserved.")
+    XCTAssertNotNil(chapter2, "Chapter 2 must be preserved.")
+    XCTAssertEqual(partI?.position.track.key, chapter2?.position.track.key, "Part I and Chapter 2 share one physical file...")
+    XCTAssertNotEqual(partI?.position.timestamp, chapter2?.position.timestamp, "...at DISTINCT offsets, so both are kept.")
+  }
+
+  /// SWAP-GUARD: replacing the app's 1.5x gate with the toolkit collapse must NOT
+  /// un-collapse a densely-subdivided title the app collapses today. "The Martian"
+  /// (41 TOC entries over 8 files) is the ONE real shipping title that trips 1.5x;
+  /// the toolkit must now collapse it to one chapter per physical file — the same
+  /// grouping the app produced — fixing martian's latent toolkit/app divergence too.
+  func testTheMartian_denseTOCCollapsesToOnePerFile() throws {
+    let manifest = try Manifest.from(
+      jsonFileName: "the_martian_manifest", bundle: Bundle(for: type(of: self)))
+    let tracks = Tracks(manifest: manifest, audiobookID: testID, token: nil)
+    let toc = AudiobookTableOfContents(manifest: manifest, tracks: tracks)
+    let distinctKeys = Set(toc.toc.map { $0.position.track.key }).count
+    XCTAssertEqual(toc.toc.count, distinctKeys, "Dense TOC must collapse to one chapter per physical track.key.")
+    XCTAssertLessThan(toc.toc.count, 41, "Martian's 41-entry dense TOC must be collapsed (was 41 uncollapsed).")
+    XCTAssertEqual(toc.toc.count, 7, "Martian collapses to its 7 physical files (matches the app's 1.5x grouping).")
+  }
+
+  /// SWAP-GUARD (element-identical): martian must collapse to the SAME 7 chapters
+  /// the app's keep-first-per-key produces today — TITLES + ORDER, not just count.
+  /// A keep-first that picked different representatives would still be 7 but wrong.
+  func testTheMartian_collapsedChaptersAreElementIdenticalToAppGrouping() throws {
+    let manifest = try Manifest.from(
+      jsonFileName: "the_martian_manifest", bundle: Bundle(for: type(of: self)))
+    let tracks = Tracks(manifest: manifest, audiobookID: testID, token: nil)
+    let toc = AudiobookTableOfContents(manifest: manifest, tracks: tracks)
+    let titles = toc.toc.map { $0.title }
+    XCTAssertEqual(
+      titles,
+      ["Opening Credits", "Chapter 2", "Chapter 3", "Chapter 4", "Chapter 5", "Chapter 6", "Chapter 7"],
+      "Collapsed martian must be element-identical (first chapter per physical file, in order) to the app's grouping."
+    )
+    // No duplicate physical keys remain.
+    XCTAssertEqual(Set(toc.toc.map { $0.position.track.key }).count, toc.toc.count, "No duplicate track.key in collapsed TOC.")
+  }
+
+  /// NO-OP: a normal title with distinct keys, not dense, no @ts0 dups (Findaway
+  /// "secret_lives": 10 unique (part,seq)) must be UNCHANGED — collapse is a no-op
+  /// for the common case.
+  func testNormalFindawayTitle_collapseIsNoOp() throws {
+    let manifest = try Manifest.from(
+      jsonFileName: "secret_lives_manifest", bundle: Bundle(for: type(of: self)))
+    let tracks = Tracks(manifest: manifest, audiobookID: testID, token: nil)
+    let toc = AudiobookTableOfContents(manifest: manifest, tracks: tracks)
+    XCTAssertEqual(toc.toc.count, 10, "Normal Findaway title (10 unique keys) must be untouched by collapse; got \(toc.toc.count).")
+    XCTAssertEqual(Set(toc.toc.map { $0.position.track.key }).count, 10, "All 10 chapters keep distinct physical keys.")
+  }
+}

--- a/PalaceAudiobookToolkitTests/ManifestJSON.swift
+++ b/PalaceAudiobookToolkitTests/ManifestJSON.swift
@@ -55,12 +55,12 @@ enum ManifestJSON: String, CaseIterable {
     case .bigFail: 22
     case .bocas: 14
     case .christmasCarol: 6
-    case .flatland: 25
+    case .flatland: 9  // 25 dense TOC entries collapse to 9 physical files (1.5x gate)
     case .littleWomenDevotional: 54
-    case .martian: 41
+    case .martian: 7  // 41 dense TOC entries collapse to 7 physical files (1.5x gate)
     case .bestNewHorror: 7
     case .quickSilver: 29
-    case .snowcrash: 72
+    case .snowcrash: 24  // 72 dense TOC entries collapse to 24 physical files (1.5x gate)
     case .secretLives: 10
     case .theSystemOfTheWorld: 47
     case .endOfTheWorld: 14

--- a/PalaceAudiobookToolkitTests/TestResources/dune_oversubdivided_manifest.json
+++ b/PalaceAudiobookToolkitTests/TestResources/dune_oversubdivided_manifest.json
@@ -1,0 +1,32 @@
+{
+ "metadata": {
+  "author": ["Herbert, Frank"],
+  "@type": "http://bib.schema.org/Audiobook",
+  "title": "Dune (synthetic oversubdivided Findaway repro)",
+  "encrypted": {
+   "findaway:licenseId": "00000000000000000000repro",
+   "findaway:sessionKey": "00000000-0000-0000-0000-000000repro",
+   "findaway:checkoutId": "00000000000000000000chkout",
+   "findaway:fulfillmentId": "32884",
+   "findaway:accountId": "REPRO-acct",
+   "scheme": "http://librarysimplified.org/terms/drm/scheme/FAE"
+  },
+  "identifier": "urn:librarysimplified.org/terms/id/Findaway%20ID/32884",
+  "language": "en",
+  "duration": 4943.924
+ },
+ "links": [
+  { "rel": "cover", "href": "https://example.org/cover/32884" }
+ ],
+ "@context": [
+  "http://readium.org/webpub/default.jsonld",
+  { "findaway": "http://librarysimplified.org/terms/third-parties/findaway.com/" }
+ ],
+ "readingOrder": [
+  {"findaway:part": 1, "findaway:sequence": 1, "title": "Chapter 1", "type": "audio/mpeg", "duration": 600.0},
+  {"findaway:part": 1, "findaway:sequence": 3, "title": "Chapter 2", "type": "audio/mpeg", "duration": 1257.874},
+  {"findaway:part": 1, "findaway:sequence": 3, "title": "Chapter 3", "type": "audio/mpeg", "duration": 998.243},
+  {"findaway:part": 1, "findaway:sequence": 3, "title": "Chapter 4", "type": "audio/mpeg", "duration": 1387.807},
+  {"findaway:part": 1, "findaway:sequence": 4, "title": "Chapter 5", "type": "audio/mpeg", "duration": 700.0}
+ ]
+}


### PR DESCRIPTION
## What
Repairs **dual chapter-numbering** on oversubdivided Findaway titles ("Dune", Findaway id 32884) and the same latent divergence on dense-TOC titles. Multiple chapters resolve to ONE physical audio file (several readingOrder entries share a `findaway:(part,sequence)` → one `track.key`, all at offset 0). The toolkit resolved `currentChapter` / NowPlaying / saved-position against that inflated list while the app already displayed the collapsed list → dual numbering, and a 30s skip never crossed a non-existent intra-file boundary.

## How
`AudiobookTableOfContents` now owns **one** collapse (the app's `normalizedChapters` becomes a passthrough — single source, no second list to drift):
- **Dense TOC** (`toc.count > tracks×1.5`, e.g. *The Martian* 41 entries / 8 files): keep one chapter per physical `track.key`. This is the app's historical 1.5× threshold, **moved verbatim** so the grouping is element-identical.
- **Not-dense + exact-duplicate positions** (same key, same `@ts0` — Findaway *Dune*): drop duplicates, keep first.
- **Distinct offsets within a file** (legitimate multi-chapter-per-file, e.g. *Dungeon Crawler Carl*): **preserved**.

Keep-first (chapter unchanged, matching the app); durations are **not** summed (oversubdivided sub-durations aren't additive sub-ranges of the physical file).

## Tests — `FindawayOversubdividedTOCTests` (8, all green)
- Dune → 3 (positive); chapter(forPosition: 1:3@34.757) → single chapter.
- DCC → 7 preserved (negative / PP-3518, distinct offsets).
- Martian → 7, **element-identical** titles+order (swap-guard).
- secret_lives → 10 (no-op).
- Existing `testChapterCounts` updated for now-collapsed dense titles (martian 41→7, flatland 25→9, snowcrash 72→24 — latent divergences the app already displayed collapsed).

Run: `xcodebuild -project ../Palace.xcodeproj -scheme PalaceAudiobookToolkit -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:PalaceAudiobookToolkitTests/FindawayOversubdividedTOCTests test`

## Known limitation (upstream, not client-fixable)
For Dune 32884 the upstream Bibliotheca/Findaway manifest is itself mis-keyed (real "Chapter 2" audio lives in a file the manifest never references). This fix restores navigation consistency + saved==played, but cannot recover a never-referenced file — that is an upstream content fix.

## Scope
Does not change the player/engine, position-save format, or the Manifest decoder. The pre-existing `animalFarm_manifest` decode failure in `TableOfContentsTests` is an unrelated malformed non-manifest fixture (red on base `28de55a3`), out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)