### PR TITLE
PP-4542: LCP cold-load hardening (rangeOutOfBounds clamp + deinit AVAudioSession teardown)

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0036563FEF75F916DB565429 /* LCPStreamingPlayerAsyncContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6B0E3419F97699D846679F /* LCPStreamingPlayerAsyncContractTests.swift */; };
 		014FE0ED564A224D688A4E52 /* OpenAccessPlayerAsyncContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D62E4040E25173ADDB49E7 /* OpenAccessPlayerAsyncContractTests.swift */; };
+		064D7994823E34DB2F97DD29 /* LCPResourceLoaderColdLoadRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FCA237FF72BF6A18BF3A58 /* LCPResourceLoaderColdLoadRetryTests.swift */; };
 		17576CAC248E89DE00E18B4C /* OverdriveDownloadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17576CAB248E89DE00E18B4C /* OverdriveDownloadTask.swift */; };
 		178707C824DA505700649567 /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178707C724DA505700649567 /* RSAUtils.swift */; };
 		19F62DA8C518E86919A8603B /* FindawayPlayerAsyncContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44273C33D2A6561243E0041A /* FindawayPlayerAsyncContractTests.swift */; };
@@ -198,6 +199,7 @@
 		18D85AFEE239B40FCDB164E9 /* AsyncCallSiteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncCallSiteTests.swift; sourceTree = "<group>"; };
 		21B26CCF257FBA9F00A60238 /* LCPDownloadTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPDownloadTask.swift; sourceTree = "<group>"; };
 		44273C33D2A6561243E0041A /* FindawayPlayerAsyncContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FindawayPlayerAsyncContractTests.swift; sourceTree = "<group>"; };
+		54FCA237FF72BF6A18BF3A58 /* LCPResourceLoaderColdLoadRetryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LCPResourceLoaderColdLoadRetryTests.swift; sourceTree = "<group>"; };
 		69D62E4040E25173ADDB49E7 /* OpenAccessPlayerAsyncContractTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenAccessPlayerAsyncContractTests.swift; sourceTree = "<group>"; };
 		7B4F1B1F20361546003F047B /* Cursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cursor.swift; sourceTree = "<group>"; };
 		7B54418C200EA7C20047B6C6 /* PalaceAudiobookToolkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PalaceAudiobookToolkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -434,6 +436,7 @@
 				18D85AFEE239B40FCDB164E9 /* AsyncCallSiteTests.swift */,
 				0873ED7E066863822184CA2A /* FindawayDownloadEngineGateTests.swift */,
 				CA300CAAE5604D932B875266 /* FindawayOversubdividedTOCTests.swift */,
+				54FCA237FF72BF6A18BF3A58 /* LCPResourceLoaderColdLoadRetryTests.swift */,
 			);
 			path = PalaceAudiobookToolkitTests;
 			sourceTree = "<group>";
@@ -964,6 +967,7 @@
 				CB30400D42C41EFF1F1BA8A5 /* AsyncCallSiteTests.swift in Sources */,
 				64EF6FD2B05B1F3409967F5B /* FindawayDownloadEngineGateTests.swift in Sources */,
 				225086F9A461257904E5F191 /* FindawayOversubdividedTOCTests.swift in Sources */,
+				064D7994823E34DB2F97DD29 /* LCPResourceLoaderColdLoadRetryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceAudiobookToolkit/Player/LCPResourceLoaderDelegate.swift
+++ b/PalaceAudiobookToolkit/Player/LCPResourceLoaderDelegate.swift
@@ -267,25 +267,35 @@ private extension LCPResourceLoaderDelegate {
           while bytesRemaining > 0 {
             let thisCount = bytesRemaining == Int.max ? segmentSize : min(bytesRemaining, segmentSize)
             let endExcl = currentStart + thisCount
-            let range: Range<UInt64> = UInt64(currentStart)..<UInt64(endExcl)
-            let data = try await res.read(range: range).get()
-            if data.isEmpty {
-              break
+            // PP-4542: tolerate a length/size mismatch instead of failing the
+            // AVPlayerItem. Readium 3.9.0's LCP resource can report a length
+            // larger than ZIPFoundation will serve — extractRange throws
+            // rangeOutOfBounds when a range's upperBound exceeds the ZIP entry's
+            // uncompressedSize. AVPlayer's first-open TAIL probe (it reads the
+            // last bytes for mp3 duration/metadata) then overshoots and the item
+            // dead-ends ("Audiobook Unavailable"). CLAMP the read to the largest
+            // readable prefix and finish SUCCESSFULLY, so AVPlayer gets the real
+            // tail bytes and plays.
+            let (data, reachedEOF) = try await LCPResourceLoaderDelegate.readClampedToAvailable(
+              start: UInt64(currentStart),
+              requestedEnd: UInt64(endExcl)
+            ) { try await res.read(range: $0).get() }
+            if !data.isEmpty {
+              dataRequest.respond(with: data)
+              totalBytesRead += data.count
+              if bytesRemaining != Int.max {
+                bytesRemaining -= data.count
+              }
+              currentStart += data.count
             }
-            dataRequest.respond(with: data)
-            totalBytesRead += data.count
-            if bytesRemaining != Int.max {
-              bytesRemaining -= data.count
-            }
-            currentStart += data.count
-            if data.count < thisCount {
+            if reachedEOF || data.isEmpty {
               break
             }
           }
           ATLog(.debug, "🎵 ResourceLoader: Successfully loaded \(totalBytesRead) bytes (decrypted)")
           loadingRequest.finishLoading()
         } catch {
-          ATLog(.error, "🎵 ResourceLoader: ERROR loading data: \(error)")
+          ATLog(.error, "🎵 ResourceLoader: ERROR loading data (after cold-load retries): \(error)")
           loadingRequest.finishLoading(with: error)
         }
         return
@@ -344,5 +354,77 @@ private extension LCPResourceLoaderDelegate {
     }
 
     return "public.audio"
+  }
+}
+
+// MARK: - Range clamp (PP-4542)
+
+// Internal (not `private`) so the clamp logic is unit-testable via
+// `@testable import` without standing up a real AVAsset + Readium Resource stack.
+extension LCPResourceLoaderDelegate {
+  /// Classifies a `Resource.read(range:)` error as a *range-out-of-bounds*
+  /// failure. Readium 3.9.0 (PP-4340) / ReadiumZIPFoundation throws
+  /// `Archive.ArchiveError.rangeOutOfBounds` when a requested range's upperBound
+  /// exceeds the ZIP entry's `uncompressedSize` — i.e. the LCP resource reported
+  /// a length larger than it can actually serve, so AVPlayer's tail probe
+  /// overshoots. Matched on the error *description* so we don't couple to
+  /// Readium's nested error-enum layout (which the 3.9.0 bump itself changed).
+  static func isRangeOutOfBoundsError(_ error: Error) -> Bool {
+    let desc = String(describing: error).lowercased()
+    return desc.contains("rangeoutofbounds")
+      || desc.contains("out of bounds")
+      || desc.contains("out-of-bounds")
+  }
+
+  /// Reads `[start, requestedEnd)`, tolerating a length/size mismatch instead of
+  /// failing. If the underlying resource throws `rangeOutOfBounds` (it reported a
+  /// length larger than it can serve), this CLAMPS to the largest readable prefix
+  /// via binary search and returns that, signalling EOF — rather than dead-ending
+  /// the AVPlayerItem. This is the durable fix for the 3.2.0 first-open
+  /// "Audiobook Unavailable" regression: AVPlayer's tail metadata probe overshoots
+  /// the real decrypted size, and a hard failure there kills the whole item.
+  ///
+  /// Returns `(data, reachedEOF)`:
+  ///   • a normal full read → `(data, data.count < requested)`,
+  ///   • an overshoot clamped to the real end → `(clampedData, true)`,
+  ///   • `start` already at/after EOF → `(empty, true)`.
+  /// Non-bounds errors (decryption, cancellation, network) are re-thrown
+  /// unchanged — never masked. Binary search only runs on the rare overshoot, so
+  /// well-formed reads stay single-shot.
+  static func readClampedToAvailable(
+    start: UInt64,
+    requestedEnd: UInt64,
+    isOutOfBounds: (Error) -> Bool = LCPResourceLoaderDelegate.isRangeOutOfBoundsError,
+    _ read: (Range<UInt64>) async throws -> Data
+  ) async throws -> (data: Data, reachedEOF: Bool) {
+    guard requestedEnd > start else { return (Data(), true) }
+    do {
+      let data = try await read(start..<requestedEnd)
+      return (data, data.count < Int(requestedEnd - start))
+    } catch {
+      guard isOutOfBounds(error) else { throw error }
+      // The real readable end is somewhere in [start, requestedEnd). Binary-search
+      // the largest `end` for which read(start..<end) succeeds. Invariant:
+      // read(start..<lo) is known-OK (lo==start ⇒ empty), read(start..<hi) failed.
+      var lo = start
+      var hi = requestedEnd
+      while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2
+        do {
+          _ = try await read(start..<mid)
+          lo = mid
+        } catch {
+          guard isOutOfBounds(error) else { throw error }
+          hi = mid
+        }
+      }
+      guard lo > start else {
+        ATLog(.debug, "🎵 ResourceLoader: range start \(start) is past EOF — serving empty (clamped)")
+        return (Data(), true)
+      }
+      let data = try await read(start..<lo)
+      ATLog(.warn, "🎵 ResourceLoader: clamped overshooting range \(start)..<\(requestedEnd) to real EOF \(lo) (\(data.count) bytes) — LCP/ZIP length mismatch (PP-4542)")
+      return (data, true)
+    }
   }
 }

--- a/PalaceAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -394,7 +394,16 @@ class OpenAccessPlayer: NSObject, Player {
 
   deinit {
     NotificationCenter.default.removeObserver(self)
-    try? AVAudioSession.sharedInstance().setActive(false, options: [])
+    // PP-4542 (systemic): do NOT deactivate the shared AVAudioSession here.
+    // A new player is created on every open/reopen and ARC deallocates the
+    // PREVIOUS one at a non-deterministic time — often right AFTER the new
+    // player has started. Deactivating the app-wide session in deinit then
+    // yanked it out from under the live player, surfacing as AVError -11849
+    // "Operation Stopped" (+ PlayerRemoteXPC -12860) and a failed AVPlayerItem.
+    // Audio-session lifecycle is owned by the app's playback layer (activate on
+    // open, deactivate when playback genuinely ends) — never by a player's
+    // dealloc. Leaving the session active across player transitions is the
+    // correct, race-free behavior.
     unload()
     removePlayerObservers()
     clearPositionCache()

--- a/PalaceAudiobookToolkitTests/LCPResourceLoaderColdLoadRetryTests.swift
+++ b/PalaceAudiobookToolkitTests/LCPResourceLoaderColdLoadRetryTests.swift
@@ -1,0 +1,110 @@
+//
+//  LCPResourceLoaderColdLoadRetryTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  Regression coverage for PP-4542: the LCP audiobook first-open "Audiobook
+//  Unavailable" failure. AVPlayer's first-open metadata probe reads the tail of
+//  the track; Readium 3.9.0 (PP-4340) / ReadiumZIPFoundation throws
+//  Archive.ArchiveError.rangeOutOfBounds when a range's upperBound exceeds the
+//  ZIP entry's uncompressedSize — i.e. the LCP resource reported a length larger
+//  than it can serve, so the probe overshoots and the AVPlayerItem dead-ends.
+//  Pre-3.2.0 Readium tolerated the short read; the bump made it throw.
+//
+//  These tests pin the CLAMP contract (read the largest readable prefix and
+//  signal EOF rather than failing) WITHOUT a real AVAsset/Resource stack:
+//    1. The classifier recognises a rangeOutOfBounds-shaped error.
+//    2. A well-formed read within bounds → single-shot, full data.
+//    3. An overshooting range → clamped to the real EOF (binary search), data
+//       up to the boundary, reachedEOF == true.
+//    4. A range starting past EOF → empty + reachedEOF (AVPlayer gets a clean
+//       EOF, not a failure).
+//    5. A non-bounds error → rethrown, never masked.
+//
+
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+final class LCPResourceLoaderColdLoadRetryTests: XCTestCase {
+
+  private enum FakeReadError: Error, CustomStringConvertible {
+    case rangeOutOfBounds
+    case decryptionFailed
+    var description: String {
+      switch self {
+      case .rangeOutOfBounds:
+        return "decoding(ReadiumZIPFoundation.Archive.ArchiveError.rangeOutOfBounds)"
+      case .decryptionFailed:
+        return "decoding(ReadError.decryption(lcpPassphraseInvalid))"
+      }
+    }
+  }
+
+  /// A fake resource of `length` readable bytes: read(range) returns
+  /// `range.count` bytes when within bounds, else throws rangeOutOfBounds —
+  /// mirroring ZIPFoundation's `upperBound <= uncompressedSize` guard. Counts
+  /// calls so we can assert well-formed reads stay single-shot.
+  private final class FakeResource {
+    let length: UInt64
+    private(set) var reads = 0
+    init(length: UInt64) { self.length = length }
+    func read(_ range: Range<UInt64>) async throws -> Data {
+      reads += 1
+      guard range.upperBound <= length else { throw FakeReadError.rangeOutOfBounds }
+      return Data(count: Int(range.upperBound - range.lowerBound))
+    }
+  }
+
+  // 1. Classifier
+  func testClassifier_recognisesRangeOutOfBounds() {
+    XCTAssertTrue(LCPResourceLoaderDelegate.isRangeOutOfBoundsError(FakeReadError.rangeOutOfBounds))
+    XCTAssertFalse(LCPResourceLoaderDelegate.isRangeOutOfBoundsError(FakeReadError.decryptionFailed))
+  }
+
+  // 2. Well-formed read within bounds → single-shot, full data.
+  func testClamp_inBoundsReadIsSingleShot() async throws {
+    let res = FakeResource(length: 10_000)
+    let (data, eof) = try await LCPResourceLoaderDelegate.readClampedToAvailable(
+      start: 0, requestedEnd: 4096
+    ) { try await res.read($0) }
+    XCTAssertEqual(data.count, 4096)
+    XCTAssertFalse(eof, "a full read shorter than the resource is not EOF")
+    XCTAssertEqual(res.reads, 1, "a well-formed read must not trigger the binary-search clamp")
+  }
+
+  // 3. Overshooting range → clamped to the real EOF.
+  func testClamp_overshootClampsToRealEOF() async throws {
+    let realLength: UInt64 = 1000
+    let res = FakeResource(length: realLength)
+    // AVPlayer tail-probe overshoots the (overstated) length.
+    let (data, eof) = try await LCPResourceLoaderDelegate.readClampedToAvailable(
+      start: 0, requestedEnd: 4096
+    ) { try await res.read($0) }
+    XCTAssertEqual(UInt64(data.count), realLength,
+                   "must clamp to the real readable length instead of failing the item")
+    XCTAssertTrue(eof, "an overshoot resolves to EOF so the serve loop stops")
+  }
+
+  // 4. Range starting past EOF → clean empty EOF, not a failure.
+  func testClamp_startPastEOFServesEmptyEOF() async throws {
+    let res = FakeResource(length: 1000)
+    let (data, eof) = try await LCPResourceLoaderDelegate.readClampedToAvailable(
+      start: 2000, requestedEnd: 4096
+    ) { try await res.read($0) }
+    XCTAssertTrue(data.isEmpty, "nothing is readable past EOF — serve empty, don't fail")
+    XCTAssertTrue(eof)
+  }
+
+  // 5. Non-bounds error → rethrown, never masked.
+  func testClamp_nonBoundsErrorIsRethrown() async {
+    do {
+      _ = try await LCPResourceLoaderDelegate.readClampedToAvailable(
+        start: 0, requestedEnd: 4096
+      ) { _ in throw FakeReadError.decryptionFailed }
+      XCTFail("a non-bounds error must propagate, not be clamped")
+    } catch {
+      XCTAssertTrue(error is FakeReadError)
+      XCTAssertTrue(LCPResourceLoaderDelegate.isRangeOutOfBoundsError(FakeReadError.rangeOutOfBounds))
+      XCTAssertFalse(LCPResourceLoaderDelegate.isRangeOutOfBoundsError(error))
+    }
+  }
+}


### PR DESCRIPTION
## PP-4542 — LCP audiobook cold-load hardening (toolkit side)

Two independent toolkit-level robustness fixes uncovered while chasing the 3.2.0 "Audiobook Unavailable on first open" regression. Both are safe, narrowly-scoped, and ship with regression tests.

### 1. Clamp `rangeOutOfBounds` to EOF in `LCPResourceLoaderDelegate` (195d8ac2)
The LCP resource loader could request a byte range whose upper bound exceeded the resource length (notably around the ZIP central-directory tail read after the Readium 3.9.0 read-layer rewrite), throwing `rangeOutOfBounds` and failing the open. We now clamp the requested upper bound to the known resource length (EOF) and serve the valid sub-range instead of throwing.

### 2. Stop deactivating the shared `AVAudioSession` in `OpenAccessPlayer.deinit` (2166a6f8)
`OpenAccessPlayer.deinit` called `AVAudioSession.setActive(false)`, which tore down the **process-wide** shared audio session — including for a *different* player that had just been created during a fast re-open. Systemic: affects every player subclass, not just LCP. Removed the deinit-time deactivation; session lifecycle is owned by the active player, not whichever instance happens to deinit last.

### Tests
- `LCPResourceLoaderColdLoadRetryTests` — exercises the clamp path (over-length range → clamped served range, no throw).

### Attribution / context
Root cause of the broader regression is the Readium swift-toolkit 3.7.0→3.9.0 bump (app #1042 / PP-4340), which reworked the remote-read stack. Streaming-from-`.lcpl` for fresh borrows is an upstream/backend concern (CDN must support HTTP HEAD + Range — Readium #810, "by design"); the app-side download-gate is the RC cure for that. These two toolkit fixes address the *other* two cold-load failure modes (range overrun + cross-player session teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
