### PR TITLE
fix(manifest): exempt Overdrive (contentlinks) from root invariant (PP-4631)

### DIFF
--- a/PalaceAudiobookToolkit/Player/Helpers/Models/Manifest.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Models/Manifest.swift
@@ -114,7 +114,16 @@ public struct Manifest: Codable {
     let hasReadingOrder = (readingOrder?.isEmpty == false)
     let hasSpine = (spine?.isEmpty == false)
     let hasMetadata = (metadata != nil)
-    if !hasMetadata || (!hasReadingOrder && !hasSpine) {
+    // PP-4631: Overdrive audiobook manifests legitimately carry neither
+    // `metadata` nor `readingOrder`/`spine` at the root — their playable
+    // tracks come from `links.contentlinks` (see Tracks.addTracksFromLinks;
+    // audiobookType == .overdrive). Exempt that shape from the invariant so a
+    // valid Overdrive manifest is not rejected before the contentLinks track
+    // path can run. The strict check is preserved for all other manifests
+    // (the F-005 / Crashlytics 7bf923ee crash guard).
+    let hasContentLinks = (linksDictionary?.contentLinks?.isEmpty == false)
+    let isOverdriveManifest = (formatType?.contains("overdrive") == true) && hasContentLinks
+    if !isOverdriveManifest, !hasMetadata || (!hasReadingOrder && !hasSpine) {
       var missing: [String] = []
       if !hasMetadata { missing.append("metadata") }
       if !hasReadingOrder && !hasSpine { missing.append("readingOrder|spine") }


### PR DESCRIPTION
## What
Exempt the Overdrive audiobook manifest shape from the `Manifest` decode root-invariant added in 3d1046b8.

## Why (PP-4631 — 3.2.0 Blocker)
The invariant rejects any manifest lacking `metadata` or `readingOrder`/`spine`. Overdrive manifests legitimately have **neither** — their playable tracks come from `links.contentlinks` (`Tracks.initializeTracks`; `audiobookType == .overdrive`). So every OverDrive audiobook open failed with *"Manifest is missing required root field(s)"*. Device-confirmed fixed on iPhone 17 Pro Max.

## Scope / safety
Exemption requires BOTH `formatType` contains `overdrive` **and** non-empty `contentLinks` — narrower than `audiobookType`'s own detection. The strict check (F-005 / Crashlytics 7bf923ee guard) is preserved for Findaway/LCP/OpenAccess and for broken Overdrive (no contentlinks). Downstream Overdrive path verified safe (no metadata/readingOrder deref; TOC skips duration calc for .overdrive).

## Tests
Gated regression guards added app-side in ios-core PalaceTests (the toolkit test target is not CI-gated — see follow-up). Note: `PalaceAudiobookToolkitTests` should be wired into CI + given Overdrive carve-outs (animalFarm fixture vs testMetadata_AllFormats) as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)