### PR TITLE
PP-4518: extend audiobook playback speed range to 0.5x–3.0x

### DIFF
--- a/PalaceAudiobookToolkit/Core/HumanReadablePlaybackRate.swift
+++ b/PalaceAudiobookToolkit/Core/HumanReadablePlaybackRate.swift
@@ -34,9 +34,17 @@ class HumanReadablePlaybackRate {
       return NSLocalizedString("Normal speed.", bundle: Bundle.audiobookToolkit()!, value: "Normal speed.", comment: "")
     case .doubleTime:
       return NSLocalizedString(
-        "Two times normal speed. Fastest.",
+        "Two times normal speed.",
         bundle: Bundle.audiobookToolkit()!,
-        value: "Two times normal speed. Fastest.",
+        value: "Two times normal speed.",
+        comment: ""
+      )
+    case .tripleTime:
+      // PP-4518: 3.0× is the new ceiling and therefore the fastest speed.
+      return NSLocalizedString(
+        "Three times normal speed. Fastest.",
+        bundle: Bundle.audiobookToolkit()!,
+        value: "Three times normal speed. Fastest.",
         comment: ""
       )
     default:

--- a/PalaceAudiobookToolkit/Player/FindawayPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/FindawayPlayer.swift
@@ -314,14 +314,17 @@ class FindawayPlayer: NSObject, Player {
       let cachedValue = UserDefaults.standard.double(forKey: audioPlaybackRateIdentifierKey)
       guard cachedValue != 0 else {
         if let value = audioEngine?.playbackEngine?.currentRate {
-          return PlaybackRate(rawValue: Int(value * 100))!
+          // PP-4518: snap to the nearest enum step rather than force-unwrap —
+          // the Findaway SDK may report a rate that has no exact case (and the
+          // rail now spans 0.5×–3.0×, widening the chance of a mismatch).
+          return PlaybackRate.nearest(to: value)
         } else {
           return .normalTime
         }
       }
 
       audioEngine?.playbackEngine?.currentRate = Float(cachedValue)
-      return PlaybackRate(rawValue: Int(cachedValue * 100))!
+      return PlaybackRate.nearest(to: Float(cachedValue))
     }
 
     set(newRate) {

--- a/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/LCPStreamingPlayer.swift
@@ -515,7 +515,10 @@ class LCPStreamingPlayer: OpenAccessPlayer, StreamingCapablePlayer {
         return nil
       }
     }
-    return AVPlayerItem(asset: composition)
+    let item = AVPlayerItem(asset: composition)
+    // PP-4518: preserve narrator pitch across the full 0.5×–3.0× range.
+    item.audioTimePitchAlgorithm = .timeDomain
+    return item
   }
 
   // Build a single item for a specific index using the same priority: local file -> streaming -> placeholder

--- a/PalaceAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/PalaceAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -1391,7 +1391,10 @@ extension OpenAccessPlayer {
 
   private func createPlayerItem(files: [URL]) -> AVPlayerItem? {
     guard files.count > 1 else {
-      return AVPlayerItem(url: files[0])
+      let item = AVPlayerItem(url: files[0])
+      // PP-4518: preserve narrator pitch across the full 0.5×–3.0× range.
+      item.audioTimePitchAlgorithm = .timeDomain
+      return item
     }
 
     let composition = AVMutableComposition()
@@ -1422,7 +1425,10 @@ extension OpenAccessPlayer {
       return nil
     }
 
-    return AVPlayerItem(asset: composition)
+    let item = AVPlayerItem(asset: composition)
+    // PP-4518: preserve narrator pitch across the full 0.5×–3.0× range.
+    item.audioTimePitchAlgorithm = .timeDomain
+    return item
   }
 
   @objc func playerItemDidReachEnd(_ notification: Notification) {

--- a/PalaceAudiobookToolkit/Player/Player.swift
+++ b/PalaceAudiobookToolkit/Player/Player.swift
@@ -19,8 +19,14 @@ public enum PlaybackRate: Int, CaseIterable {
   case oneAndAQuarterTime = 125
   case oneAndAHalfTime = 150
   case doubleTime = 200
+  case tripleTime = 300
 
-  // Intermediate 0.05× steps
+  // Intermediate 0.05× steps (PP-4518: rail extended to 0.50× … 3.00×)
+  case p050 = 50
+  case p055 = 55
+  case p060 = 60
+  case p065 = 65
+  case p070 = 70
   case p080 = 80
   case p085 = 85
   case p090 = 90
@@ -42,22 +48,46 @@ public enum PlaybackRate: Int, CaseIterable {
   case p185 = 185
   case p190 = 190
   case p195 = 195
+  case p205 = 205
+  case p210 = 210
+  case p215 = 215
+  case p220 = 220
+  case p225 = 225
+  case p230 = 230
+  case p235 = 235
+  case p240 = 240
+  case p245 = 245
+  case p250 = 250
+  case p255 = 255
+  case p260 = 260
+  case p265 = 265
+  case p270 = 270
+  case p275 = 275
+  case p280 = 280
+  case p285 = 285
+  case p290 = 290
+  case p295 = 295
 
   public static func convert(rate: PlaybackRate) -> Float {
     Float(rate.rawValue) * 0.01
   }
 
   /// Preset rates shown as quick-select chips in the speed picker UI.
-  /// PP-4358 locks this to [0.75×, 1.0×, 1.2×, 1.5×, 2.0×]. The third
-  /// preset is `.p120` (1.20×), not `.oneAndAQuarterTime` (1.25×) — the
-  /// PP-4233 design review picked 1.2× over 1.25×. `.oneAndAQuarterTime`
-  /// remains a valid enum case so historic UserDefaults values (raw 125)
-  /// still decode for users who selected 1.25× before this change.
+  /// PP-4518 product direction: even 0.5× steps across the full rail —
+  /// [0.5×, 1.0×, 1.5×, 2.0×, 2.5×, 3.0×]. This supersedes the earlier
+  /// PP-4358/PP-4233 ladder. 0.75× and 1.25× are intentionally NOT chips:
+  ///   - Android parity (ThePalaceProject/android-audiobook PlayerPlaybackRate.kt
+  ///     ships 0.5/1.0/1.25/1.5/2.0/2.5/3.0 and likewise drops 0.75×), so
+  ///     omitting 0.75× is Android-aligned;
+  ///   - we deliberately omit Android's 1.25× in favor of an even 0.5 ladder.
+  /// Both `.threeQuartersTime` (raw 75) and `.oneAndAQuarterTime` (raw 125)
+  /// remain valid enum cases — historic UserDefaults values still decode and
+  /// both stay reachable on the 0.05-step slider for accessibility slow-down.
   public static let presets: [PlaybackRate] = [
-    .threeQuartersTime, .normalTime, .p120, .oneAndAHalfTime, .doubleTime
+    .p050, .normalTime, .oneAndAHalfTime, .doubleTime, .p250, .tripleTime
   ]
 
-  /// All available steps in ascending order (0.75× → 2.0×)
+  /// All available steps in ascending order (0.50× → 3.0×)
   public static let steps: [PlaybackRate] = PlaybackRate.allCases.sorted { $0.rawValue < $1.rawValue }
 
   /// Returns the PlaybackRate whose multiplier is closest to `value`

--- a/PalaceAudiobookToolkit/UI/SpeedSliderSheet.swift
+++ b/PalaceAudiobookToolkit/UI/SpeedSliderSheet.swift
@@ -19,8 +19,10 @@ struct SpeedSliderSheet: View {
   @State private var sliderValue: Double = 1.0
 
   private let step: Double = 0.05
-  private let minRate: Double = 0.75
-  private let maxRate: Double = 2.0
+  // PP-4518: slider rail spans 0.5× … 3.0×. The 0.75× preset chip remains the
+  // quick-select slow-down, but the rail floor drops to 0.5× per acceptance.
+  private let minRate: Double = 0.5
+  private let maxRate: Double = 3.0
 
   // MARK: - Computed labels
 


### PR DESCRIPTION
## Summary

PP-4518: extend the audiobook playback speed range from a 0.75×–2.0× cap to **0.5×–3.0×**, bringing Palace in line with Libby/Audible and the Palace Android app. The cap, presets, and rate handling all live here in the toolkit; the consuming app (ios-core) only passes `PlaybackRate`/`.presets` through and gets a companion submodule-bump + tests PR.

## Changes

- **`Player.swift` — `PlaybackRate`**: extended to **51 cases, 0.50×–3.00× in 0.05 steps** (adds `.tripleTime = 300`, `p050…p070`, `p205…p295`). `steps` / `nearest(to:)` / clamp extend automatically.
- **Preset chips** → even 0.5 ladder **`[0.5, 1.0, 1.5, 2.0, 2.5, 3.0]`** (`.p050, .normalTime, .oneAndAHalfTime, .doubleTime, .p250, .tripleTime`). 0.75× and 1.25× are intentionally not quick-select chips but remain valid enum cases (historic UserDefaults raw 75/120 still decode) and reachable on the 0.05-step slider for accessibility slow-down.
- **`SpeedSliderSheet.swift`**: rail widened to min 0.5, max 3.0.
- **`HumanReadablePlaybackRate.swift`**: "Fastest" VoiceOver label moved from 2.0× to 3.0×; 3.0× announcement added.
- **Pitch preservation fix (latent bug):** the multi-file composition paths — `OpenAccessPlayer.createPlayerItem(files:)` (incl. its single-file fallback) and `LCPStreamingPlayer.createConcatenatedItem(from:)` — did **not** set `audioTimePitchAlgorithm`, so multi-file audiobooks vari-speed (pitch rises) above ~1×. All three composition paths now set `.timeDomain` (pitch-preserving). Single-track items already had it. This satisfies the "pitch-preserving across the full range" requirement and was broken pre-change for multi-file titles.
- **`FindawayPlayer.swift`**: hardened the two rate getters from force-unwrap `PlaybackRate(rawValue:)!` → `PlaybackRate.nearest(to:)`, so an SDK-reported rate outside the (now wider) enum can't crash.

## Preset decision

The even-0.5 ladder (dropping the 0.75× *chip*) was confirmed directly by the maintainer after reviewing Android parity: Android's latest `PlayerPlaybackRate` ships `0.5/1.0/1.25/1.5/2.0/2.5/3.0` and **also drops 0.75×**, so dropping it is Android-aligned. We deliberately omit Android's 1.25× in favor of an even ladder. 0.75× stays reachable on the slider.

## Verification

- **Build:** `** BUILD SUCCEEDED **` (Palace scheme via ios-core, iPhone 16 Pro).
- **Unit:** `PlaybackRateTests` — 18/18, `** TEST SUCCEEDED **` (preset order + even-0.5 spacing, two chips >2.0×, 0.75×/1.2× dropped-from-chips-but-reachable, clamp 0.5/3.0, rawValue restart round-trip, `2.75x`/`3.0x` formatting, VoiceOver Fastest = 3.0×). Tests live in the companion ios-core PR.
- **Live player:** the speed-sheet chips were validated locally by the maintainer.

## Companion PR

ios-core gets a submodule-pointer bump to this branch's merge commit + the `PlaybackRateTests`. That PR runs the full ios-core suite (incl. audiobook cross-vendor smoke) and must merge after this one.
