### PR TITLE
fix(swift6): make PalaceAuthTokenProvider.tokenResolver concurrency-safe (PP-4723)

### DIFF
--- a/PalaceAudiobookToolkit/Core/PalaceAuthTokenProvider.swift
+++ b/PalaceAudiobookToolkit/Core/PalaceAuthTokenProvider.swift
@@ -4,7 +4,20 @@ import Foundation
 /// The main app sets `tokenResolver` at launch so the toolkit can refresh bearer
 /// tokens using the correct credentials during streaming playback.
 public enum PalaceAuthTokenProvider {
-  public static var tokenResolver: (() -> String?)? = nil
+  private static let lock = NSLock()
+  private static var _tokenResolver: (@Sendable () -> String?)?
+
+  /// The main app installs a resolver at launch; the toolkit reads it from its
+  /// networking layer (`OpenAccessDownloadTask` / `OpenAccessPlayer`) off the
+  /// main thread during streaming playback. Under Swift 6 a bare
+  /// `public static var` is shared mutable state and not concurrency-safe, so
+  /// the storage is lock-guarded and the resolver closure is `@Sendable`. The
+  /// accessors are synchronous, so `lock()`/`unlock()` are legal here (the
+  /// async-context ban does not apply).
+  public static var tokenResolver: (@Sendable () -> String?)? {
+    get { lock.lock(); defer { lock.unlock() }; return _tokenResolver }
+    set { lock.lock(); defer { lock.unlock() }; _tokenResolver = newValue }
+  }
 
   public static var currentToken: String? {
     tokenResolver?()


### PR DESCRIPTION
## What

Make `PalaceAuthTokenProvider.tokenResolver` concurrency-safe under Swift 6.

Under Swift 6 language mode a bare `public static var tokenResolver` is shared mutable
state and is not concurrency-safe. The Palace iOS app (now migrating to Swift 6 —
finish-line PR) errors when it installs the resolver at launch. This makes the storage
lock-backed and the resolver closure `@Sendable`.

## Why it's correct

- The accessors are **synchronous**, so `lock()`/`unlock()` are legal (the Swift 6
  async-context ban does not apply here).
- The toolkit reads `currentToken` **off the main thread** during streaming
  (`OpenAccessDownloadTask`, `OpenAccessPlayer`), so lock-guarding the storage slot also
  closes a real pre-existing cross-thread read/write race — the resolver closure is
  invoked *outside* the lock (getter returns the value before `?()` applies it), so a
  re-entrant resolver cannot deadlock.

## Behavior

Unchanged: same resolver, same token value, `nil`-until-launch preserved.

## Context

Part of the Palace iOS Swift 6 modernization finish line (epic PP-4717 / PP-4723). The
app-side Phase C PR bumps this submodule pointer to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
