### PR TITLE
feat: audiobook player polish + iOS 17 bump (contrast fix, play/pause morph, haptics)

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -1035,7 +1035,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1094,7 +1094,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1126,7 +1126,7 @@
 				);
 				INFOPLIST_FILE = PalaceAudiobookToolkit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1165,7 +1165,7 @@
 				);
 				INFOPLIST_FILE = PalaceAudiobookToolkit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1192,7 +1192,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = PalaceAudiobookToolkitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1216,7 +1216,7 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = PalaceAudiobookToolkitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -113,6 +113,9 @@ public struct AudiobookPlayerView: View {
         playbackModel.stop()
       }
     }
+    // PP-4156 class: the player commits to its dark visual design (Color(white:0.15)
+    // panels, white-opacity chips). Pinning the scheme prevents white-on-white in light mode.
+    .preferredColorScheme(.dark)
   }
   
   // MARK: - Portrait Layout
@@ -242,6 +245,8 @@ public struct AudiobookPlayerView: View {
       .shadow(color: .white.opacity(0.08), radius: 4, x: 0, y: -1)
       .padding(.horizontal, isLandscape ? 0 : 20)
       .padding(.vertical, isLandscape ? 15 : 0)
+      .scaleEffect(playbackModel.isPlaying ? 1.0 : 0.94)
+      .animation(.spring(response: 0.35, dampingFraction: 0.7), value: playbackModel.isPlaying)
       .animation(.easeInOut(duration: 0.2), value: playbackModel.isDownloading)
       .animation(.easeInOut(duration: 0.3), value: playbackModel.coverImage == nil)
   }
@@ -331,7 +336,10 @@ public struct AudiobookPlayerView: View {
     let size: CGFloat = isLandscape ? 44 : (horizontalSizeClass == .compact ? 52 : 72)
     let labelFont: Font = isLandscape ? .system(size: 11) : (horizontalSizeClass == .compact ? .system(size: 13, weight: .medium) : .system(size: 16, weight: .medium))
     let secFont: Font = isLandscape ? .system(size: 8) : (horizontalSizeClass == .compact ? .system(size: 9) : .system(size: 11))
-    Button(action: action) {
+    Button(action: {
+      UIImpactFeedbackGenerator(style: .light).impactOccurred()
+      action()
+    }) {
       ToolkitImage(name: imageName, renderingMode: .template)
         .overlay(
           VStack(spacing: -2) {
@@ -345,6 +353,7 @@ public struct AudiobookPlayerView: View {
         )
         .frame(width: size, height: size)
     }
+    .buttonStyle(PressableScaleButtonStyle())
     .accessibilityLabel(accessibilityString)
     .foregroundColor(.primary)
   }
@@ -357,17 +366,12 @@ public struct AudiobookPlayerView: View {
       ZStack {
         Circle()
           .fill(Color.white.opacity(0.12))
-        if isPlaying {
-          ToolkitImage(name: "pause", renderingMode: .template)
-            .frame(width: iconSize, height: iconSize)
-        } else {
-          ToolkitImage(name: "play", renderingMode: .template)
-            .frame(width: iconSize, height: iconSize)
-            .offset(x: isLandscape ? 3 : 5)
-        }
+        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+          .font(.system(size: iconSize))
+          .frame(width: iconSize, height: iconSize)
+          .contentTransition(.symbolEffect(.replace))
       }
       .frame(width: bgSize, height: bgSize)
-      .animation(.none, value: isPlaying)
     }
     .foregroundColor(.primary)
     .accessibilityLabel(Text(isPlaying ? Strings.Accessibility.pauseButton : Strings.Accessibility.playButton))
@@ -744,104 +748,17 @@ struct AVRoutePickerViewWrapper: View {
   }
 }
 
-// MARK: - AudiobookSlider
+// MARK: - PressableScaleButtonStyle
 
-/// High-performance audiobook slider with smooth seeking and haptic feedback
-struct AudiobookSlider: View {
-  @Binding var value: Double
-  @State private var isDragging: Bool = false
-  @State private var dragValue: Double = 0.0
-  @State private var lastHapticValue: Double = -1.0
-  @State private var committedValue: Double = 0.0
-
-  let onDragChanged: (Double) -> Void
-  let onDragEnded: (Double) -> Void
-
-  var body: some View {
-    GeometryReader { geometry in
-      ZStack(alignment: .leading) {
-        // Background track
-        Rectangle()
-          .fill(.gray)
-          .frame(height: trackHeight)
-
-        // Progress track with minimal animation
-        Rectangle()
-          .fill(Color(.label))
-          .frame(width: progressWidth(in: geometry.size), height: trackHeight)
-          .animation(.easeOut(duration: isDragging ? 0.0 : 0.1), value: isDragging ? dragValue : value)
-
-        // Thumb with subtle visual feedback
-        Capsule()
-          .fill(Color.red)
-          .frame(width: thumbWidth, height: thumbHeight)
-          .offset(x: thumbOffset(in: geometry.size))
-          .scaleEffect(isDragging ? 1.05 : 1.0)
-          .animation(.easeOut(duration: 0.1), value: isDragging)
-          .gesture(
-            DragGesture()
-              .onChanged { gesture in
-                let newValue = max(0, min(1, Double(gesture.location.x / geometry.size.width)))
-
-                if !isDragging {
-                  isDragging = true
-                  dragValue = newValue
-                } else {
-                  dragValue = newValue
-                }
-
-                // Minimal haptic feedback for professional feel
-                provideSubtleHapticFeedback(for: newValue)
-
-                // Visual feedback only during drag
-                onDragChanged(newValue)
-              }
-              .onEnded { _ in
-                isDragging = false
-                committedValue = dragValue
-
-                // Subtle completion feedback
-                let impact = UIImpactFeedbackGenerator(style: .light)
-                impact.impactOccurred()
-
-                // Perform seeking on drag end
-                onDragEnded(dragValue)
-              }
-          )
-          .accessibilityLabel(Strings.Accessibility.audiobookPlaybackSlider)
-      }
-    }
-    .frame(height: thumbHeight)
+/// Button style that gives a subtle spring-driven pressed-scale, used by the
+/// skip-back / skip-forward controls for a tactile press response.
+struct PressableScaleButtonStyle: ButtonStyle {
+  var scale: CGFloat = 0.88
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .scaleEffect(configuration.isPressed ? scale : 1.0)
+      .animation(.spring(response: 0.3, dampingFraction: 0.6), value: configuration.isPressed)
   }
-
-  // MARK: - Helper Methods
-
-  private func progressWidth(in size: CGSize) -> CGFloat {
-    let currentValue = isDragging ? dragValue : (committedValue > 0 ? max(value, committedValue) : value)
-    return CGFloat(currentValue) * size.width
-  }
-
-  private func thumbOffset(in size: CGSize) -> CGFloat {
-    let currentValue = isDragging ? dragValue : (committedValue > 0 ? max(value, committedValue) : value)
-    return CGFloat(currentValue) * (size.width - thumbWidth)
-  }
-
-  private func provideSubtleHapticFeedback(for newValue: Double) {
-    // Very subtle haptic feedback only at start/end boundaries
-    if abs(newValue - lastHapticValue) > 0.2 {
-      if abs(newValue - 0.0) < 0.02 || abs(newValue - 1.0) < 0.02 {
-        let impact = UIImpactFeedbackGenerator(style: .light)
-        impact.impactOccurred()
-        lastHapticValue = newValue
-      }
-    }
-  }
-
-  // MARK: - View configuration
-
-  private let thumbWidth: CGFloat = 10
-  private let thumbHeight: CGFloat = 36
-  private let trackHeight: CGFloat = 10
 }
 
 // MARK: - PlaybackSliderView
@@ -904,6 +821,8 @@ struct PlaybackSliderView: View {
             if let finalValue = tempValue {
               isCommitting = true
               value = finalValue
+              // Salvaged from the removed AudiobookSlider: subtle completion haptic on seek commit.
+              UIImpactFeedbackGenerator(style: .light).impactOccurred()
               onChange(finalValue)
               DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 tempValue = nil

--- a/PalaceAudiobookToolkit/UI/SpeedSliderSheet.swift
+++ b/PalaceAudiobookToolkit/UI/SpeedSliderSheet.swift
@@ -67,6 +67,8 @@ struct SpeedSliderSheet: View {
       let nearest = PlaybackRate.nearest(to: Float(newValue))
       if nearest != playbackRate {
         playbackRate = nearest
+        // Detent tick as the committed rate crosses to a new step.
+        UISelectionFeedbackGenerator().selectionChanged()
         UIAccessibility.post(notification: .announcement, argument: speedAccessibleDescription)
       }
     }


### PR DESCRIPTION
**Jira:** PP-4749 — the audiobook-toolkit stage of the Palace iOS *world-class UI motion & polish* initiative (main-app stages: PRs #1200/#1202/#1203/#1204 on ThePalaceProject/ios-core). Presentation-only; no playback/seek/position/manifest/DRM logic touched.

Verified by building the **main Palace app** against this branch (the toolkit can't build standalone — it imports the app's `PalaceUIKit`): `** BUILD SUCCEEDED **` at both the bump and the full-polish checkpoints.

### Changes
- **iOS 17 deployment-target bump** — all 6 configs (13.0/16.0/16.6) → 17.0, matching the app (which moved to 17 in ios-core #1200). Unlocks the modern motion APIs used below.
- **Contrast fix (PP-4156 class)** — the full player hard-codes a dark look (`Color.white.opacity(...)` chips + white text on `Color(white:0.15)` panels), which risked unreadable white-on-white in **light mode**. Added `.preferredColorScheme(.dark)` on the player root so the screen commits to its dark design in both system appearances. ⚠️ **Needs a light+dark simdrive visual check before the app adopts this** (see below).
- **Play/pause morph** — replaced two PNG images hard-swapped under `.animation(.none)` with SF Symbols `play.fill`/`pause.fill` + `.contentTransition(.symbolEffect(.replace))` (dropped the manual offset).
- **Skip-button haptic + pressed-scale**; **speed-dial detent haptic** (`SpeedSliderSheet`).
- **Cover art** gently scales on pause/resume.
- **Dead code** — removed the unused `AudiobookSlider` (~100 LOC; live control is `PlaybackSliderView`), salvaging its drag-end haptic.

### Deferred (focused follow-up)
Chapter-list highlight animation, bookmark glyph confirmation, buffering-state on the play button, loading→playing cross-fade, and the broad deprecated-API/`.foregroundColor` sweep — each needs per-surface visual verification.

### Adoption gate
The app's submodule pointer is NOT bumped here. Before a follow-up ios-core PR adopts this commit, run the **simdrive light+dark visual check on the now-playing screen** (per the PP-4156 / PP-1168 dark-mode wall-failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)