### PR TITLE
fix(nodrm): weak-link AudioEngine + gate Findaway so the open build launches

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		E52C1C4D2C00437F00D8F30B /* flatland_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E549653227FBEAC400913BD6 /* flatland_manifest.json */; };
 		E52C1C4E2C00437F00D8F30B /* the_system_of_the_world_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E58C53432B75507100D861EE /* the_system_of_the_world_manifest.json */; };
 		E530533029B69BDC005E831F /* snowcrash_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E530532F29B69B91005E831F /* snowcrash_manifest.json */; };
-		E531FF072D0691D70003E2FA /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5ECFA9B2BED70E80008670F /* AudioEngine.xcframework */; };
+		E531FF072D0691D70003E2FA /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5ECFA9B2BED70E80008670F /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E5338AD12BEAB816002387E1 /* littleWomenDevotional_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E5338AD02BEAB816002387E1 /* littleWomenDevotional_manifest.json */; };
 		E5338AD52BEABFC3002387E1 /* FindawayAudiobook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58FCC632BE09ED200943CEB /* FindawayAudiobook.swift */; };
 		E53A1B792C3E443200F490CD /* ManifestJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52C1C3F2C00435700D8F30B /* ManifestJSON.swift */; };
@@ -1139,6 +1139,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1177,6 +1178,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1201,6 +1203,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = PalaceAudiobooksToolkit.PalaceAudiobookToolkitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1225,6 +1228,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = PalaceAudiobooksToolkit.PalaceAudiobookToolkitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/PalaceAudiobookToolkit/Core/Audiobook.swift
+++ b/PalaceAudiobookToolkit/Core/Audiobook.swift
@@ -45,8 +45,13 @@ public enum AudiobookFactory {
     for manifest: Manifest
   ) -> Audiobook.Type {
     switch manifest.audiobookType {
-    case .findaway:
+    #if FEATURE_FINDAWAY
+    // Findaway playback requires the proprietary AudioEngine SDK. When it isn't
+    // linked (the open, no-DRM build) fall through to OpenAccess rather than
+    // touching absent AudioEngine symbols. Mirrors Android's optional Findaway.
+    case .findaway where FindawaySupport.isAvailable:
       FindawayAudiobook.self
+    #endif
     default:
       OpenAccessAudiobook.self
     }
@@ -160,8 +165,10 @@ class DynamicPlayerFactory: PlayerFactoryProtocol {
         return LCPStreamingPlayer(tableOfContents: toc, drmDecryptor: decryptor)
       }
 
-    case .findaway:
+    #if FEATURE_FINDAWAY
+    case .findaway where FindawaySupport.isAvailable:
       return FindawayPlayer(tableOfContents: toc) ?? OpenAccessPlayer(tableOfContents: toc)
+    #endif
     default:
       return OpenAccessPlayer(tableOfContents: toc)
     }

--- a/PalaceAudiobookToolkit/Player/Helpers/AudiobookLifecycleManager.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/AudiobookLifecycleManager.swift
@@ -19,6 +19,25 @@ import UIKit
   init()
 }
 
+// MARK: - FindawaySupport
+
+/// Whether Findaway's proprietary `AudioEngine` framework is actually present in
+/// this process.
+///
+/// The toolkit weak-links `AudioEngine`, so the same binary runs in builds that
+/// embed it (full-DRM Palace) and builds that don't (the open, no-DRM build,
+/// which must not ship the proprietary SDK). This mirrors Android's
+/// `org.thepalaceproject.findaway.enabled` property (default `false`): where the
+/// SDK is absent, every Findaway code path is skipped rather than dyld-faulting
+/// on a missing library at launch.
+///
+/// `FAEAudioEngine` is AudioEngine's Obj-C principal class; `NSClassFromString`
+/// resolves it only when the framework is loaded. Evaluated once — the set of
+/// loaded frameworks does not change over a process's lifetime.
+enum FindawaySupport {
+  static let isAvailable: Bool = (NSClassFromString("FAEAudioEngine") != nil)
+}
+
 // MARK: - AudiobookLifecycleManager
 
 /// Hooks into life cycle events for AppDelegate.swift. Listens to notifcations from
@@ -59,10 +78,18 @@ import UIKit
   override public init() {
     super.init()
     
-    // Register all audiobook lifecycle listeners
-    let findawayListener = FindawayAudiobookLifecycleListener()
-    listeners.append(findawayListener)
-    
+    // Register the Findaway lifecycle listener only when the AudioEngine SDK is
+    // actually linked into this process. In the open (no-DRM) build AudioEngine
+    // is absent, so constructing this listener — which registers for the
+    // AudioEngine-defined `FAEDatabaseVerificationComplete` notification — would
+    // reference a symbol dyld cannot resolve. Mirrors Android's
+    // `findaway.enabled = false` open build.
+    #if FEATURE_FINDAWAY
+    if FindawaySupport.isAvailable {
+      listeners.append(FindawayAudiobookLifecycleListener())
+    }
+    #endif
+
     // Register OpenAccess background session listener
     let openAccessListener = OpenAccessBackgroundListener()
     listeners.append(openAccessListener)


### PR DESCRIPTION
## Problem
`Palace-noDRM` (the open build) **crashes at launch** — a dyld failure before `main`:

```
dyld: Library not loaded: @rpath/AudioEngine.framework/AudioEngine
  Referenced from: …/Palace-noDRM.app/Frameworks/PalaceAudiobookToolkit.framework/PalaceAudiobookToolkit
```

The open build embeds `PalaceAudiobookToolkit` but **not** Findaway's proprietary `AudioEngine.framework` (by design — it must not ship proprietary SDKs). The toolkit **hard-linked** AudioEngine (`LC_LOAD_DYLIB`), so dyld couldn't resolve it and killed the process.

**Regression origin:** PP-1059 "refactor audiobook player" (2024-08-16) folded `AudioEngine.xcframework` into the toolkit's own framework target as a required link. Before that the toolkit had no direct AudioEngine reference (it was resolved at app level, DRM-target-only). The Android app never had this problem — it keeps Findaway optional via `org.thepalaceproject.findaway.enabled` (default `false`).

## Fix — mirror Android's optional Findaway
- **Weak-link** `AudioEngine.xcframework` (`LC_LOAD_WEAK_DYLIB`) so the single shared toolkit binary loads with or without AudioEngine embedded. No-op where present (full-DRM Palace).
- `FindawaySupport.isAvailable` = `NSClassFromString("FAEAudioEngine") != nil` — true only when AudioEngine is actually loaded.
- Gate the startup lifecycle-listener registration and both `AudiobookFactory` `.findaway` seams on `#if FEATURE_FINDAWAY && FindawaySupport.isAvailable`; the open build falls through to OpenAccess and never touches absent AudioEngine symbols.
- Define `FEATURE_FINDAWAY` on the framework + test targets (**default on**) so the full-DRM build is byte-for-byte unchanged.

## Verification (on sim — iPhone 17 Pro / iOS 26.1)
| | Build | Launch | AudioEngine | Findaway |
|---|---|---|---|---|
| **noDRM** | ✅ | ✅ launches to first-run picker → full catalog loads (**was crashing**) | not embedded, **weak** | skipped |
| **DRM (Palace)** | ✅ | ✅ healthy | **embedded**, weak, resolves | active |

Only the `.findaway` path is altered — `OpenAccess`/`LCP` audiobook paths are untouched.

> **On testing:** this is a dyld link/load fix. A missing-library load failure can't be reproduced in a unit test (the test host always has AudioEngine), so it's verified on-device in both build variants rather than by XCTest.

## Base
Targets `feat/expose-playback-state` because the app pins that branch's tip (`095dfa10`, the in-app custom-player APIs). This PR = that tip + one commit, so the app pointer bump is a clean +1.

**Not done (follow-up):** full compile-time strip of Findaway for the open build (Android's exact mechanism) needs a dedicated Findaway-free toolkit target. Endgame: the Boundless replacement retiring Findaway entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)