### PR TITLE
fix(nodrm): gate TrackFactory .findaway seam (defense-in-depth follow-up)

### DIFF
--- a/PalaceAudiobookToolkit/Player/Helpers/Tracks/Tracks.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Tracks/Tracks.swift
@@ -37,7 +37,14 @@ class TrackFactory: TrackFactoryProtocol {
     key: String?
   ) -> (any Track)? {
     switch manifest.audiobookType {
-    case .findaway:
+    #if FEATURE_FINDAWAY
+    // Defense-in-depth: `FindawayTrack` builds a `FindawayDownloadTask`, which
+    // constructs `FAEDownloadRequest` (AudioEngine). When AudioEngine isn't
+    // linked (the open, no-DRM build) fall through to `OpenAccessTrack` rather
+    // than force-unwrapping an absent Obj-C class. The `AudiobookFactory` gate
+    // already keeps a no-DRM catalog off this path; this closes the residual
+    // window if a Findaway-typed manifest ever reaches the open build.
+    case .findaway where FindawaySupport.isAvailable:
       try? FindawayTrack(
         manifest: manifest,
         urlString: urlString,
@@ -47,6 +54,7 @@ class TrackFactory: TrackFactoryProtocol {
         index: index,
         token: token
       )
+    #endif
     case .lcp:
       try? LCPTrack(
         manifest: manifest,


### PR DESCRIPTION
Follow-up to #190. Gates the one remaining `.findaway` site that touches AudioEngine.

`TrackFactory.createTrack` `.findaway` → `FindawayTrack` → `FindawayDownloadTask` → `FAEDownloadRequest` (weak-linked, absent in the open build) → force-unwrap crash. Now gated on `#if FEATURE_FINDAWAY && FindawaySupport.isAvailable`, falling through to `OpenAccessTrack` — same pattern as the `AudiobookFactory` seams.

Unreachable in the open build today (`AudiobookFactory` already returns OpenAccess; a no-DRM catalog is never served a Findaway manifest), so this is **defense-in-depth**, not a live crash. Flagged by the independent review of #190.

The other two `.findaway` sites the review enumerated were verified to **not** touch AudioEngine and are intentionally left unchanged (`Manifest.profile` reads manifest data; `TOC.downloadProgress` reads a protocol property) — gating them would be behavior-changing churn with no safety benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)