### PR TITLE
PP-4712: independently configurable audiobook skip intervals (player)

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		E52C1C4D2C00437F00D8F30B /* flatland_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E549653227FBEAC400913BD6 /* flatland_manifest.json */; };
 		E52C1C4E2C00437F00D8F30B /* the_system_of_the_world_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E58C53432B75507100D861EE /* the_system_of_the_world_manifest.json */; };
 		E530533029B69BDC005E831F /* snowcrash_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E530532F29B69B91005E831F /* snowcrash_manifest.json */; };
-		E531FF072D0691D70003E2FA /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5ECFA9B2BED70E80008670F /* AudioEngine.xcframework */; };
+		E531FF072D0691D70003E2FA /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5ECFA9B2BED70E80008670F /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E5338AD12BEAB816002387E1 /* littleWomenDevotional_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = E5338AD02BEAB816002387E1 /* littleWomenDevotional_manifest.json */; };
 		E5338AD52BEABFC3002387E1 /* FindawayAudiobook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58FCC632BE09ED200943CEB /* FindawayAudiobook.swift */; };
 		E53A1B792C3E443200F490CD /* ManifestJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52C1C3F2C00435700D8F30B /* ManifestJSON.swift */; };
@@ -1139,6 +1139,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1177,6 +1178,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1201,6 +1203,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = PalaceAudiobooksToolkit.PalaceAudiobookToolkitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1225,6 +1228,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = PalaceAudiobooksToolkit.PalaceAudiobookToolkitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) FEATURE_FINDAWAY";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/PalaceAudiobookToolkit/Core/Audiobook.swift
+++ b/PalaceAudiobookToolkit/Core/Audiobook.swift
@@ -45,8 +45,13 @@ public enum AudiobookFactory {
     for manifest: Manifest
   ) -> Audiobook.Type {
     switch manifest.audiobookType {
-    case .findaway:
+    #if FEATURE_FINDAWAY
+    // Findaway playback requires the proprietary AudioEngine SDK. When it isn't
+    // linked (the open, no-DRM build) fall through to OpenAccess rather than
+    // touching absent AudioEngine symbols. Mirrors Android's optional Findaway.
+    case .findaway where FindawaySupport.isAvailable:
       FindawayAudiobook.self
+    #endif
     default:
       OpenAccessAudiobook.self
     }
@@ -160,8 +165,10 @@ class DynamicPlayerFactory: PlayerFactoryProtocol {
         return LCPStreamingPlayer(tableOfContents: toc, drmDecryptor: decryptor)
       }
 
-    case .findaway:
+    #if FEATURE_FINDAWAY
+    case .findaway where FindawaySupport.isAvailable:
       return FindawayPlayer(tableOfContents: toc) ?? OpenAccessPlayer(tableOfContents: toc)
+    #endif
     default:
       return OpenAccessPlayer(tableOfContents: toc)
     }

--- a/PalaceAudiobookToolkit/Core/AudiobookManager.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookManager.swift
@@ -58,6 +58,13 @@ public protocol AudiobookManager {
   var totalDuration: Double { get }
   var currentChapter: Chapter? { get }
 
+  /// Patron-configurable skip intervals in seconds, independently settable for
+  /// each direction. Default 30 each (see the extension below); a host injects
+  /// patron-chosen values. Drives the in-app player, the on-screen skip-button
+  /// labels, and the remote/lock-screen/CarPlay skip commands.
+  var skipForwardInterval: TimeInterval { get }
+  var skipBackInterval: TimeInterval { get }
+
   func updateNowPlayingInfo(_ position: TrackPosition?)
 
   static func setLogHandler(_ handler: @escaping LogHandler)
@@ -76,6 +83,13 @@ public protocol AudiobookManager {
   var statePublisher: PassthroughSubject<AudiobookManagerState, Never> { get }
 
   var playbackCompletionHandler: (() -> Void)? { get set }
+}
+
+public extension AudiobookManager {
+  /// Back-compat default: conformers that don't configure skip intervals keep
+  /// the historical 30s skip until a host injects patron-configured values.
+  var skipForwardInterval: TimeInterval { DefaultAudiobookManager.skipTimeInterval }
+  var skipBackInterval: TimeInterval { DefaultAudiobookManager.skipTimeInterval }
 }
 
 // MARK: - BookmarkError
@@ -181,6 +195,12 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
   private var didAnnounceDownloadStart: Bool = false
 
   public static let skipTimeInterval: TimeInterval = 30
+
+  /// Patron-configurable skip intervals, defaulting to `skipTimeInterval` (30s).
+  /// A host (the Palace app's Playback settings) sets these per manager; they
+  /// drive the in-app player, the on-screen button labels, and remote commands.
+  public var skipForwardInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
+  public var skipBackInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
 
   // MARK: - Enhanced Position System
 
@@ -850,7 +870,7 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
         case .skipForward, .nextTrack:
           Task { [weak self] in
             guard let self = self else { return }
-            let newPosition = await audiobook.player.skipPlayhead(DefaultAudiobookManager.skipTimeInterval)
+            let newPosition = await audiobook.player.skipPlayhead(self.skipForwardInterval)
             guard let newPosition = newPosition else { return }
             await MainActor.run {
               self.updateNowPlayingInfo(newPosition)
@@ -863,7 +883,7 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
         case .skipBackward, .previousTrack:
           Task { [weak self] in
             guard let self = self else { return }
-            let newPosition = await audiobook.player.skipPlayhead(-DefaultAudiobookManager.skipTimeInterval)
+            let newPosition = await audiobook.player.skipPlayhead(-self.skipBackInterval)
             guard let newPosition = newPosition else { return }
             await MainActor.run {
               self.updateNowPlayingInfo(newPosition)

--- a/PalaceAudiobookToolkit/Core/AudiobookManager.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookManager.swift
@@ -199,8 +199,12 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
   /// Patron-configurable skip intervals, defaulting to `skipTimeInterval` (30s).
   /// A host (the Palace app's Playback settings) sets these per manager; they
   /// drive the in-app player, the on-screen button labels, and remote commands.
-  public var skipForwardInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
-  public var skipBackInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
+  public var skipForwardInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval {
+    didSet { mediaControlPublisher.updateSkipIntervals(forward: skipForwardInterval, back: skipBackInterval) }
+  }
+  public var skipBackInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval {
+    didSet { mediaControlPublisher.updateSkipIntervals(forward: skipForwardInterval, back: skipBackInterval) }
+  }
 
   // MARK: - Enhanced Position System
 

--- a/PalaceAudiobookToolkit/Core/MediaControlPublisher.swift
+++ b/PalaceAudiobookToolkit/Core/MediaControlPublisher.swift
@@ -46,6 +46,13 @@ class MediaControlPublisher {
   private var previousTrackTarget: Any?
   private var rateTarget: Any?
 
+  // PP-4712: the skip intervals shown on the lock-screen/CarPlay controls.
+  // Default 30 each; the owning manager pushes patron-configured values via
+  // `updateSkipIntervals(forward:back:)`, which re-applies them so a foreground
+  // cycle or interruption re-config doesn't revert the badge to a hardcoded 30.
+  private var skipForwardInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
+  private var skipBackInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
+
   init() {
     setup()
     
@@ -102,19 +109,28 @@ class MediaControlPublisher {
     commandCenter.pauseCommand.isEnabled = true
     commandCenter.togglePlayPauseCommand.isEnabled = true
     commandCenter.skipForwardCommand.isEnabled = true
-    commandCenter.skipForwardCommand.preferredIntervals = [30]
+    commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: skipForwardInterval)]
     commandCenter.skipBackwardCommand.isEnabled = true
-    commandCenter.skipBackwardCommand.preferredIntervals = [30]
+    commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: skipBackInterval)]
     commandCenter.changePlaybackRateCommand.isEnabled = true
-    
+
     // PP-3679: Enable next/previous track so car hardware buttons (steering wheel)
-    // trigger 30-second skip forward/backward
+    // trigger a skip forward/backward (by the configured interval)
     commandCenter.nextTrackCommand.isEnabled = true
     commandCenter.previousTrackCommand.isEnabled = true
     commandCenter.seekForwardCommand.isEnabled = false
     commandCenter.seekBackwardCommand.isEnabled = false
     commandCenter.changeRepeatModeCommand.isEnabled = false
     commandCenter.changeShuffleModeCommand.isEnabled = false
+  }
+
+  /// PP-4712: set the patron-configured skip intervals and re-apply them to the
+  /// command center so the lock-screen/CarPlay badges match the player. Safe to
+  /// call repeatedly; `configureCommands()` is idempotent.
+  func updateSkipIntervals(forward: TimeInterval, back: TimeInterval) {
+    skipForwardInterval = forward
+    skipBackInterval = back
+    configureCommands()
   }
   
   /// Adds command targets. Should only be called once.

--- a/PalaceAudiobookToolkit/Player/Helpers/AudiobookLifecycleManager.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/AudiobookLifecycleManager.swift
@@ -19,6 +19,25 @@ import UIKit
   init()
 }
 
+// MARK: - FindawaySupport
+
+/// Whether Findaway's proprietary `AudioEngine` framework is actually present in
+/// this process.
+///
+/// The toolkit weak-links `AudioEngine`, so the same binary runs in builds that
+/// embed it (full-DRM Palace) and builds that don't (the open, no-DRM build,
+/// which must not ship the proprietary SDK). This mirrors Android's
+/// `org.thepalaceproject.findaway.enabled` property (default `false`): where the
+/// SDK is absent, every Findaway code path is skipped rather than dyld-faulting
+/// on a missing library at launch.
+///
+/// `FAEAudioEngine` is AudioEngine's Obj-C principal class; `NSClassFromString`
+/// resolves it only when the framework is loaded. Evaluated once — the set of
+/// loaded frameworks does not change over a process's lifetime.
+enum FindawaySupport {
+  static let isAvailable: Bool = (NSClassFromString("FAEAudioEngine") != nil)
+}
+
 // MARK: - AudiobookLifecycleManager
 
 /// Hooks into life cycle events for AppDelegate.swift. Listens to notifcations from
@@ -59,10 +78,18 @@ import UIKit
   override public init() {
     super.init()
     
-    // Register all audiobook lifecycle listeners
-    let findawayListener = FindawayAudiobookLifecycleListener()
-    listeners.append(findawayListener)
-    
+    // Register the Findaway lifecycle listener only when the AudioEngine SDK is
+    // actually linked into this process. In the open (no-DRM) build AudioEngine
+    // is absent, so constructing this listener — which registers for the
+    // AudioEngine-defined `FAEDatabaseVerificationComplete` notification — would
+    // reference a symbol dyld cannot resolve. Mirrors Android's
+    // `findaway.enabled = false` open build.
+    #if FEATURE_FINDAWAY
+    if FindawaySupport.isAvailable {
+      listeners.append(FindawayAudiobookLifecycleListener())
+    }
+    #endif
+
     // Register OpenAccess background session listener
     let openAccessListener = OpenAccessBackgroundListener()
     listeners.append(openAccessListener)

--- a/PalaceAudiobookToolkit/Player/Helpers/SleepTimer.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/SleepTimer.swift
@@ -19,6 +19,24 @@ import UIKit
   case endOfChapter
 }
 
+public extension SleepTimerTriggerAt {
+  /// Human-readable menu title for this sleep-timer option, matching the
+  /// toolkit player's own sleep-timer action-sheet labels
+  /// (`AudiobookPlayerView.sleepTimerTitle(for:)`). Exposed so an in-app
+  /// custom player can build its own sleep-timer menu without reimplementing
+  /// the copy.
+  var displayTitle: String {
+    typealias S = Strings.AudiobookPlayerViewController
+    switch self {
+    case .endOfChapter: return S.endOfChapter
+    case .oneHour: return S.oneHour
+    case .thirtyMinutes: return S.thirtyMinutes
+    case .fifteenMinutes: return S.fifteenMinutes
+    case .never: return S.off
+    }
+  }
+}
+
 // MARK: - TimerStopPoint
 
 private enum TimerStopPoint {

--- a/PalaceAudiobookToolkit/Player/Helpers/Tracks/Tracks.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Tracks/Tracks.swift
@@ -37,7 +37,14 @@ class TrackFactory: TrackFactoryProtocol {
     key: String?
   ) -> (any Track)? {
     switch manifest.audiobookType {
-    case .findaway:
+    #if FEATURE_FINDAWAY
+    // Defense-in-depth: `FindawayTrack` builds a `FindawayDownloadTask`, which
+    // constructs `FAEDownloadRequest` (AudioEngine). When AudioEngine isn't
+    // linked (the open, no-DRM build) fall through to `OpenAccessTrack` rather
+    // than force-unwrapping an absent Obj-C class. The `AudiobookFactory` gate
+    // already keeps a no-DRM catalog off this path; this closes the residual
+    // window if a Findaway-typed manifest ever reaches the open build.
+    case .findaway where FindawaySupport.isAvailable:
       try? FindawayTrack(
         manifest: manifest,
         urlString: urlString,
@@ -47,6 +54,7 @@ class TrackFactory: TrackFactoryProtocol {
         index: index,
         token: token
       )
+    #endif
     case .lcp:
       try? LCPTrack(
         manifest: manifest,

--- a/PalaceAudiobookToolkit/Player/Player.swift
+++ b/PalaceAudiobookToolkit/Player/Player.swift
@@ -98,6 +98,17 @@ public enum PlaybackRate: Int, CaseIterable {
   }
 }
 
+public extension PlaybackRate {
+  /// The short multiplier label shown on the speed chip, e.g. "1.0×",
+  /// "1.5×", "1.25×". Mirrors the toolkit player's own speed-chip formatting
+  /// (`AudiobookPlayerView.playbackRateText` / `SpeedSliderSheet.speedLabel`).
+  /// Exposed so an in-app custom player can label its speed control identically.
+  var displayLabel: String {
+    if self == .normalTime { return "1.0×" }
+    return HumanReadablePlaybackRate.formatMultiplier(PlaybackRate.convert(rate: self))
+  }
+}
+
 // MARK: - PlaybackState
 
 public enum PlaybackState {

--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -79,7 +79,10 @@ public class AudiobookPlaybackModel: ObservableObject {
     }
   }
 
-  let skipTimeInterval: TimeInterval = DefaultAudiobookManager.skipTimeInterval
+  /// Independently-configurable skip intervals, read live from the manager so a
+  /// host's Playback-settings change applies to subsequently opened audiobooks.
+  var skipForwardInterval: TimeInterval { audiobookManager.skipForwardInterval }
+  var skipBackInterval: TimeInterval { audiobookManager.skipBackInterval }
 
   var offset: TimeInterval {
     if let currentLocation = currentLocation,
@@ -452,7 +455,7 @@ public class AudiobookPlaybackModel: ObservableObject {
 
     Task { [weak self] in
       guard let self = self else { return }
-      let adjustedLocation = await self.audiobookManager.audiobook.player.skipPlayhead(-self.skipTimeInterval)
+      let adjustedLocation = await self.audiobookManager.audiobook.player.skipPlayhead(-self.skipBackInterval)
       await MainActor.run {
         if let adjustedLocation = adjustedLocation {
           self.currentLocation = adjustedLocation
@@ -460,7 +463,7 @@ public class AudiobookPlaybackModel: ObservableObject {
           self.notifyHomeScreenOfPositionUpdate()
         } else {
           if let currentLocation = self.currentLocation {
-            let fallbackPosition = currentLocation + (-self.skipTimeInterval)
+            let fallbackPosition = currentLocation + (-self.skipBackInterval)
             self.currentLocation = fallbackPosition
             self.saveLocation()
             self.notifyHomeScreenOfPositionUpdate()
@@ -485,7 +488,7 @@ public class AudiobookPlaybackModel: ObservableObject {
 
     Task { [weak self] in
       guard let self = self else { return }
-      let adjustedLocation = await self.audiobookManager.audiobook.player.skipPlayhead(self.skipTimeInterval)
+      let adjustedLocation = await self.audiobookManager.audiobook.player.skipPlayhead(self.skipForwardInterval)
       await MainActor.run {
         if let adjustedLocation = adjustedLocation {
           self.currentLocation = adjustedLocation
@@ -493,7 +496,7 @@ public class AudiobookPlaybackModel: ObservableObject {
           self.notifyHomeScreenOfPositionUpdate()
         } else {
           if let currentLocation = self.currentLocation {
-            let fallbackPosition = currentLocation + self.skipTimeInterval
+            let fallbackPosition = currentLocation + self.skipForwardInterval
             self.currentLocation = fallbackPosition
             self.saveLocation()
             self.notifyHomeScreenOfPositionUpdate()

--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -14,11 +14,11 @@ public class AudiobookPlaybackModel: ObservableObject {
   @Published private var reachability = Reachability()
   @Published var isWaitingForPlayer = false
   @Published var playbackProgress: Double = 0
-  @Published var isDownloading = false
-  @Published var overallDownloadProgress: Float = 0
+  @Published public var isDownloading = false
+  @Published public var overallDownloadProgress: Float = 0
   @Published var trackErrors: [String: Error] = [:]
   @Published var coverImage: UIImage?
-  @Published var toastMessage: String = ""
+  @Published public var toastMessage: String = ""
   @Published private var _isPlaying: Bool = false
 
   private var subscriptions: Set<AnyCancellable> = []
@@ -540,7 +540,7 @@ public class AudiobookPlaybackModel: ObservableObject {
     audiobookManager.sleepTimer.setTimerTo(trigger: trigger)
   }
 
-  func addBookmark(completion: @escaping (_ error: Error?) -> Void) {
+  public func addBookmark(completion: @escaping (_ error: Error?) -> Void) {
     guard let currentLocation else {
       completion(BookmarkError.bookmarkFailedToSave)
       return
@@ -619,6 +619,19 @@ public class AudiobookPlaybackModel: ObservableObject {
       }
     }
   }
+}
+
+// MARK: - Chapter-relative time accessors (in-app custom player)
+public extension AudiobookPlaybackModel {
+  /// Chapter-relative playhead position, in seconds from the start of the
+  /// current chapter. This is the raw `TimeInterval` behind the toolkit
+  /// player's `playheadOffsetText` timecode — exposed (not the formatted
+  /// string) so an in-app custom player can format it itself.
+  var chapterPlayheadOffset: TimeInterval { offset }
+
+  /// Seconds remaining in the current chapter — the raw `TimeInterval`
+  /// behind the toolkit player's `timeLeftText` timecode.
+  var chapterTimeLeft: TimeInterval { timeLeft }
 }
 
 // MARK: - PP-4156 download-indicator visibility rule

--- a/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlayerView.swift
@@ -330,6 +330,7 @@ public struct AudiobookPlayerView: View {
   private func skipButton(
     _ imageName: String,
     textLabel _: String,
+    interval: TimeInterval,
     accessibilityString: String,
     action: @escaping () -> Void
   ) -> some View {
@@ -343,7 +344,7 @@ public struct AudiobookPlayerView: View {
       ToolkitImage(name: imageName, renderingMode: .template)
         .overlay(
           VStack(spacing: -2) {
-            Text("\(Int(playbackModel.skipTimeInterval))")
+            Text("\(Int(interval))")
               .font(labelFont)
               .offset(x: -1)
             Text("sec")
@@ -473,6 +474,7 @@ public struct AudiobookPlayerView: View {
       skipButton(
         "skip_back",
         textLabel: "skip back",
+        interval: playbackModel.skipBackInterval,
         accessibilityString: Strings.Accessibility.skipBackButton,
         action: playbackModel.skipBack
       )
@@ -484,6 +486,7 @@ public struct AudiobookPlayerView: View {
       skipButton(
         "skip_forward",
         textLabel: "skip forward",
+        interval: playbackModel.skipForwardInterval,
         accessibilityString: Strings.Accessibility.skipForwardButton,
         action: playbackModel.skipForward
       )

--- a/PalaceAudiobookToolkitTests/AsyncCallSiteTests.swift
+++ b/PalaceAudiobookToolkitTests/AsyncCallSiteTests.swift
@@ -75,7 +75,7 @@ final class AsyncCallSiteTests: XCTestCase {
     await waitUntil { player.skipPlayheadCalls.count == 1 }
     await waitUntil { model.currentLocation?.timestamp == 100 }
 
-    XCTAssertEqual(player.skipPlayheadCalls.first, -model.skipTimeInterval,
+    XCTAssertEqual(player.skipPlayheadCalls.first, -model.skipBackInterval,
                    "skipBack must request skipPlayhead with NEGATIVE interval")
     XCTAssertEqual(model.currentLocation?.timestamp, 100,
                    "skipBack must apply the awaited result")
@@ -96,8 +96,41 @@ final class AsyncCallSiteTests: XCTestCase {
 
     await waitUntil { player.skipPlayheadCalls.count == 1 }
 
-    XCTAssertEqual(player.skipPlayheadCalls.first, model.skipTimeInterval,
+    XCTAssertEqual(player.skipPlayheadCalls.first, model.skipForwardInterval,
                    "skipForward must request skipPlayhead with POSITIVE interval")
+  }
+
+  /// PP-4712: the player must use the manager's INDEPENDENT forward/back
+  /// intervals, not a single shared value. Mutant: a forward/back swap (or
+  /// reading one interval for both directions) is invisible at the default
+  /// 30/30 — this asymmetric 45/15 case makes it fail.
+  func testSkip_usesConfiguredAsymmetricIntervals() async throws {
+    let manifest = try Manifest.from(jsonFileName: "alice_manifest", bundle: Bundle(for: type(of: self)))
+    let audiobook = try XCTUnwrap(
+      OpenAccessAudiobook(manifest: manifest, bookIdentifier: "async-asym-test", decryptor: nil, token: nil)
+    )
+    let player = PlayerMock(tableOfContents: audiobook.tableOfContents)
+    audiobook.player = player
+    let manager = DefaultAudiobookManager(
+      metadata: AudiobookMetadata(title: "Asym", authors: ["A"]),
+      audiobook: audiobook,
+      networkService: DefaultAudiobookNetworkService(tracks: audiobook.tableOfContents.allTracks)
+    )
+    manager.skipForwardInterval = 45
+    manager.skipBackInterval = 15
+    let model = AudiobookPlaybackModel(audiobookManager: manager)
+    let firstTrack = try XCTUnwrap(player.tableOfContents.allTracks.first)
+    player.skipPlayheadResult = .some(TrackPosition(track: firstTrack, timestamp: 45, tracks: player.tableOfContents.tracks))
+
+    model.skipForward()
+    await waitUntil { player.skipPlayheadCalls.count == 1 }
+    XCTAssertEqual(player.skipPlayheadCalls.first, 45,
+                   "skipForward must use the configured forward interval (45), not 30 or the back value")
+
+    model.skipBack()
+    await waitUntil { player.skipPlayheadCalls.count == 2 }
+    XCTAssertEqual(player.skipPlayheadCalls.last, -15,
+                   "skipBack must use the configured back interval (−15), independently of forward")
   }
 
   /// When `player.skipPlayhead` returns nil (player not ready), the model's


### PR DESCRIPTION
## PP-4712 — configurable audiobook skip intervals (toolkit half)

Makes the audiobook player's skip interval independently configurable per direction (forward / back), defaulting to 30s each so existing behavior is unchanged. The Palace app injects the patron's chosen values.

**Review this PR at the 2 PP-4712 commits** `f3ae5f5..f7fe0af` — they sit on top of 5 pre-existing `feat/expose-playback-state` commits that ios-core `develop` already pins (base `a9ba5aa8`), which is why the diff vs `main` shows them. Sequencing is the maintainer's call.

### What changed
- `AudiobookManager`: `skipForwardInterval` / `skipBackInterval` added to the protocol (+ a back-compat default extension so other conformers keep 30s) and as settable `public var`s on `DefaultAudiobookManager`; remote/CarPlay skips use them.
- `AudiobookPlaybackModel`: separate forward/back intervals sourced live from the manager; each direction skips by its own value.
- `AudiobookPlayerView`: each on-screen skip button displays its own configured value.
- `MediaControlPublisher`: reads the configured intervals (no longer hardcodes 30) and re-applies on the manager's interval change, so the lock-screen/CarPlay badge tracks the value across foreground cycles.

### Review outcome (SoD)
Independent architect + qa_test review under heka governance — **both APPROVED** after catching and fixing two real bugs a green build had missed: (1) `MediaControlPublisher` was clobbering the lock-screen interval back to 30 on every foreground; (2) an existing toolkit test referenced the renamed skip property (test-target compile break). New `testSkip_usesConfiguredAsymmetricIntervals` (45/15) guards the forward/back swap.

### Verification
Toolkit source compiles clean (verified via the app build). The toolkit **test target** can't build in a bare worktree (PalaceUIKit unavailable) — **this PR's CI is the definitive compile + test gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
