### PR TITLE
fix(overdrive): finalize background track downloads that complete after app kill (F1)

### DIFF
--- a/PalaceAudiobookToolkit/Network/OverdriveDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OverdriveDownloadTask.swift
@@ -141,8 +141,16 @@ final class OverdriveDownloadTask: DownloadTask {
   }
 
   private func downloadAsset(fromRemoteURL remoteURL: URL, toLocalDirectory finalURL: URL) {
+    // Stable, launch-independent session identifier. Swift's hashValue is
+    // per-process SipHash-seeded, so the previous `remoteURL.hashValue` produced
+    // a *different* identifier on every launch — the reconnected background
+    // session on relaunch could never match the persisted download record, so a
+    // track that finished downloading while the app was killed was silently
+    // discarded. Key the identifier on the stable (bookID, trackKey) pair.
+    // (PP-4800 root-cause contributor — F1.)
+    let stableSessionKey = hash("\(bookID)-\(key)") ?? "\(bookID)-\(key)"
     let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "")
-      .appending(".overdriveBackgroundIdentifier.\(bookID)-\(remoteURL.hashValue)")
+      .appending(".overdriveBackgroundIdentifier.\(stableSessionKey)")
     let config = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
     let delegate = DownloadTaskURLSessionDelegate(
       downloadTask: self,
@@ -156,7 +164,20 @@ final class OverdriveDownloadTask: DownloadTask {
       delegate: delegate,
       delegateQueue: nil
     )
-    
+
+    // Record the download with the coordinator so a background completion that
+    // iOS delivers after the app is killed can be finalized to `finalURL` on the
+    // next launch. Without this record, `activeDownloads` stays empty,
+    // `handleBackgroundDownloadCompletion` hits its no-mapping branch, and the
+    // finished temp file is dropped by the OS. (PP-4800 root-cause fix — F1.)
+    AudiobookDownloadCoordinator.shared.registerActiveDownload(
+      sessionIdentifier: backgroundIdentifier,
+      bookID: bookID,
+      trackKey: key,
+      originalURL: remoteURL,
+      localDestination: finalURL
+    )
+
     // Check for resume data from a previous interrupted download
     if let resumeData = DownloadPersistenceStore.shared.getResumeData(forTrackKey: key) {
       ATLog(.info, "OverdriveDownloadTask: Resuming download from saved state for: \(key)")

--- a/PalaceAudiobookToolkitTests/AudiobookDownloadCoordinatorRenameTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookDownloadCoordinatorRenameTests.swift
@@ -65,4 +65,73 @@ final class AudiobookDownloadCoordinatorRenameTests: XCTestCase {
     XCTAssertEqual(Set(downloads.map(\.trackKey)), ["track-1", "track-2"])
     XCTAssertTrue(downloads.allSatisfy { $0.bookID == bookID })
   }
+
+  // MARK: - F1: background-completion finalization (PP-4800 root cause)
+
+  /// When a track download is registered (as `OverdriveDownloadTask.downloadAsset`
+  /// now does), a background completion delivered after the app was killed is
+  /// finalized: the temp file is MOVED to the track's destination. This is the
+  /// mechanism the F1 fix relies on — wiring `registerActiveDownload` is what
+  /// makes `activeDownloads[id]` non-empty so this branch runs.
+  func testBackgroundCompletion_whenRegistered_movesTempFileToDestination() throws {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let bookID = "book-F1-finalize"
+    let session = "app.overdriveBackgroundIdentifier.f1-finalize-stable"
+    let url = URL(string: "https://ofsdirect.api.overdrive.com/track-1.mp3")!
+
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("F1FinalizeTest", isDirectory: true)
+    try? FileManager.default.removeItem(at: dir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let destination = dir.appendingPathComponent("final-track.mp3")
+    let downloadedTemp = dir.appendingPathComponent("downloaded.tmp")
+    XCTAssertTrue(FileManager.default.createFile(atPath: downloadedTemp.path,
+                                                 contents: Data("audio-bytes".utf8)))
+
+    coordinator.registerActiveDownload(
+      sessionIdentifier: session, bookID: bookID, trackKey: "track-1",
+      originalURL: url, localDestination: destination)
+
+    coordinator.handleBackgroundDownloadCompletion(
+      sessionIdentifier: session, downloadedFileURL: downloadedTemp, originalURL: url)
+
+    // Flush the coordinator's barrier queue with a sync read before asserting.
+    _ = coordinator.activeDownloads(forBookID: bookID)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path),
+      "A registered download must be finalized to its destination on background completion")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: downloadedTemp.path),
+      "The temp file must be moved, not left behind")
+    XCTAssertEqual(try? String(contentsOf: destination, encoding: .utf8), "audio-bytes")
+
+    try? FileManager.default.removeItem(at: dir)
+  }
+
+  /// Documents the F1 defect the fix closes: with NO registration (the pre-fix
+  /// state where `registerActiveDownload` was never called in production), the
+  /// coordinator has no destination and cannot finalize — so the finished file
+  /// is not moved anywhere and is lost when iOS reclaims the temp file.
+  func testBackgroundCompletion_whenNotRegistered_cannotFinalize() throws {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let session = "app.overdriveBackgroundIdentifier.f1-unregistered"
+    let url = URL(string: "https://ofsdirect.api.overdrive.com/orphan.mp3")!
+
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("F1UnregisteredTest", isDirectory: true)
+    try? FileManager.default.removeItem(at: dir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let downloadedTemp = dir.appendingPathComponent("downloaded.tmp")
+    XCTAssertTrue(FileManager.default.createFile(atPath: downloadedTemp.path,
+                                                 contents: Data("audio-bytes".utf8)))
+
+    // No registerActiveDownload — the pre-fix production behavior.
+    coordinator.handleBackgroundDownloadCompletion(
+      sessionIdentifier: session, downloadedFileURL: downloadedTemp, originalURL: url)
+    _ = coordinator.activeDownloads(forBookID: "any")  // flush
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: downloadedTemp.path),
+      "Without a registered download the coordinator has no destination and cannot finalize — the F1 gap the fix closes by wiring registerActiveDownload in downloadAsset")
+
+    try? FileManager.default.removeItem(at: dir)
+  }
 }


### PR DESCRIPTION
## Problem
OverDrive audiobook tracks download on **per-track background `URLSession`s** whose identifiers embedded `remoteURL.hashValue`. Swift's `hashValue` is per-process SipHash-seeded, so the identifier was **different on every launch**. Combined with `AudiobookDownloadCoordinator.registerActiveDownload` **never being called in production** (only in tests — grep-verified), a track that finished downloading while the app was killed could never be finalized: `activeDownloads` was empty, `handleBackgroundDownloadCompletion` hit its no-mapping branch, and iOS discarded the temp file.

Downstream effect: the book stayed manifest-only and kept streaming from the ~24h signed URLs, which then expire → AVPlayer `-1008` (the class the app's PP-4800 recovery catches reactively). This is the upstream root-cause contributor.

## Fix (OverDrive only, this pass)
- **Stable session identifier** — `sha256(bookID + trackKey)` instead of `remoteURL.hashValue`, so the reconnected background session on relaunch matches the persisted download record. Keeps the `overdriveBackgroundIdentifier` prefix the background listener matches on.
- **Wire `registerActiveDownload`** in `downloadAsset` so a completion delivered after an app kill can be finalized to the track's destination on the next launch.

## Tests
`AudiobookDownloadCoordinatorRenameTests` gains a positive/negative pair pinning the finalization mechanism: registered → temp file **moved** to destination; unregistered → **cannot finalize** (documents the exact gap).

## Scope / not done
- **Scope:** OverDrive per-track download finalization only.
- **Not done (follow-ups):** device verification of the kill→relaunch→finalize path (background `URLSession` behavior can't be unit-tested — this is the acceptance gate before it ships to users); the OpenAccess mirror of the same fix; the within-process duplicate-session "frozen progress bar" (F2).

Part of the audiobook-pipeline architectural review. Base is `feat/expose-playback-state` (the branch the app's develop currently pins), so the diff is F1-only.