### PR TITLE
fix(download): prune completed coordinator entries + OpenAccess mirror of F1

### DIFF
--- a/PalaceAudiobookToolkit/Core/AudiobookDownloadCoordinator.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookDownloadCoordinator.swift
@@ -156,20 +156,23 @@ public final class AudiobookDownloadCoordinator {
           
           // Move the downloaded file
           try fileManager.moveItem(at: downloadedFileURL, to: destinationURL)
-          
-          downloadInfo.state = .completed
-          downloadInfo.progress = 1.0
-          self.activeDownloads[sessionIdentifier] = downloadInfo
-          
+
+          // The download is finalized on disk, so the map should no longer
+          // retain it. Leaving a `.completed` entry accretes forever (both F1
+          // reviewers flagged this): it reloads every launch and never gets a
+          // production `removeActiveDownload` caller. Remove it here so the
+          // persisted state is bounded to genuinely in-flight downloads.
+          self.activeDownloads.removeValue(forKey: sessionIdentifier)
+
           ATLog(.info, "AudiobookDownloadCoordinator: Download completed and moved to: \(destinationURL.path)")
-          
+
           DispatchQueue.main.async {
             self.downloadStatePublisher.send(.downloadCompleted(sessionIdentifier: sessionIdentifier, fileURL: destinationURL))
           }
-          
-          // Persist the updated state
+
+          // Persist the updated (pruned) state
           self.persistState()
-          
+
         } catch {
           ATLog(.error, "AudiobookDownloadCoordinator: Failed to move downloaded file: \(error.localizedDescription)")
           downloadInfo.state = .failed
@@ -355,14 +358,26 @@ public final class AudiobookDownloadCoordinator {
       let data = try Data(contentsOf: url)
       let persistedDownloads = try JSONDecoder().decode([String: PersistableDownloadInfo].self, from: data)
       
-      // Convert back to DownloadInfo
+      // Convert back to DownloadInfo, pruning terminal entries so the map
+      // stays bounded across launches. An entry is dropped if it is already
+      // `.completed`/`.failed`, or if its destination file already exists on
+      // disk (the download finished out-of-band — e.g. the in-process success
+      // path moved the file without touching the coordinator). Only genuinely
+      // in-flight downloads survive the reload.
       activeDownloads = persistedDownloads.compactMapValues { persisted in
         guard let originalURL = URL(string: persisted.originalURL),
               let localDestination = URL(string: persisted.localDestination),
               let state = DownloadInfo.DownloadState(rawValue: persisted.state) else {
           return nil
         }
-        
+
+        if state == .completed || state == .failed {
+          return nil
+        }
+        if FileManager.default.fileExists(atPath: localDestination.path) {
+          return nil
+        }
+
         return DownloadInfo(
           sessionIdentifier: persisted.sessionIdentifier,
           bookID: persisted.bookID,
@@ -373,7 +388,7 @@ public final class AudiobookDownloadCoordinator {
           state: state
         )
       }
-      
+
       ATLog(.info, "AudiobookDownloadCoordinator: Loaded \(activeDownloads.count) persisted downloads")
     } catch {
       ATLog(.debug, "AudiobookDownloadCoordinator: No persisted state found or failed to load: \(error.localizedDescription)")

--- a/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -57,6 +57,12 @@ final class OpenAccessDownloadTask: DownloadTask {
   /// that effectively DDoS the content server.
   var isForbidden = false
 
+  /// The audiobook identifier this track belongs to. Threaded through from
+  /// `OpenAccessTrack` (mirroring how `OverdriveTrack` passes `audiobookID` to
+  /// `OverdriveDownloadTask`) so the download can be registered with the
+  /// coordinator for background-completion finalization.
+  let bookID: String
+
   private static let DownloadTaskTimeoutValue: TimeInterval = 60
   private var downloadURL: URL
   private var urlString: String
@@ -94,6 +100,7 @@ final class OpenAccessDownloadTask: DownloadTask {
 
   init(
     key: String,
+    bookID: String,
     downloadURL: URL,
     urlString: String,
     urlMediaType: TrackMediaType,
@@ -102,6 +109,7 @@ final class OpenAccessDownloadTask: DownloadTask {
     token: String?
   ) {
     self.key = key
+    self.bookID = bookID
     self.downloadURL = downloadURL
     self.urlString = urlString
     self.urlMediaType = urlMediaType
@@ -280,8 +288,17 @@ final class OpenAccessDownloadTask: DownloadTask {
   }
 
   private func downloadAsset(fromRemoteURL remoteURL: URL, toLocalDirectory finalURL: URL) {
+    // Stable, launch-independent session identifier. Swift's `hashValue` is
+    // per-process SipHash-seeded, so the previous `remoteURL.hashValue`
+    // produced a *different* identifier on every launch (and wasn't even
+    // book-scoped) — the reconnected background session on relaunch could
+    // never match the persisted download record, so a track that finished
+    // while the app was killed was silently discarded. Key the identifier on
+    // the stable (bookID, trackKey) pair, mirroring the OverDrive F1 fix.
+    // OpenAccess track keys are already book-scoped, so this is unique per track.
+    let stableSessionKey = hash("\(bookID)-\(key)") ?? "\(bookID)-\(key)"
     let backgroundIdentifier = (Bundle.main.bundleIdentifier ?? "")
-      .appending(".openAccessBackgroundIdentifier.\(remoteURL.hashValue)")
+      .appending(".openAccessBackgroundIdentifier.\(stableSessionKey)")
     let config = URLSessionConfiguration.background(withIdentifier: backgroundIdentifier)
 
     // Set auth headers on the session configuration so iOS preserves them
@@ -314,6 +331,19 @@ final class OpenAccessDownloadTask: DownloadTask {
       configuration: config,
       delegate: delegate,
       delegateQueue: nil
+    )
+
+    // Record the download with the coordinator so a background completion that
+    // iOS delivers after the app is killed can be finalized to `finalURL` on
+    // the next launch. Without this record, `activeDownloads` stays empty,
+    // `handleBackgroundDownloadCompletion` hits its no-mapping branch, and the
+    // finished temp file is dropped by the OS. Mirrors the OverDrive F1 fix.
+    AudiobookDownloadCoordinator.shared.registerActiveDownload(
+      sessionIdentifier: backgroundIdentifier,
+      bookID: bookID,
+      trackKey: key,
+      originalURL: remoteURL,
+      localDestination: finalURL
     )
 
     // Check for resume data from a previous interrupted download

--- a/PalaceAudiobookToolkit/Player/Helpers/Tracks/OpenAccessTrack.swift
+++ b/PalaceAudiobookToolkit/Player/Helpers/Tracks/OpenAccessTrack.swift
@@ -75,6 +75,7 @@ public class OpenAccessTrack: Track {
     self.token = token
     let task = OpenAccessDownloadTask(
       key: self.key,
+      bookID: audiobookID,
       downloadURL: url,
       urlString: urlString,
       urlMediaType: mediaType,

--- a/PalaceAudiobookToolkitTests/AudiobookDownloadCoordinatorRenameTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookDownloadCoordinatorRenameTests.swift
@@ -134,4 +134,50 @@ final class AudiobookDownloadCoordinatorRenameTests: XCTestCase {
 
     try? FileManager.default.removeItem(at: dir)
   }
+
+  // MARK: - Prune completed entries (F1 fast-follow — both reviewers flagged)
+
+  /// After a background completion finalizes the file, the entry must be
+  /// PRUNED from `activeDownloads` — not left `.completed`. Without pruning,
+  /// every finished download reloads forever on each launch (unbounded growth,
+  /// no production `removeActiveDownload` caller). Asserts both: (a) the file
+  /// is at its destination, and (b) the entry no longer appears for the book.
+  func testBackgroundCompletion_whenRegistered_prunesEntryAfterFinalizing() throws {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let bookID = "book-prune-after-complete"
+    let session = "app.overdriveBackgroundIdentifier.prune-stable"
+    let url = URL(string: "https://ofsdirect.api.overdrive.com/track-1.mp3")!
+
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("PruneAfterCompleteTest", isDirectory: true)
+    try? FileManager.default.removeItem(at: dir)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let destination = dir.appendingPathComponent("final-track.mp3")
+    let downloadedTemp = dir.appendingPathComponent("downloaded.tmp")
+    XCTAssertTrue(FileManager.default.createFile(atPath: downloadedTemp.path,
+                                                 contents: Data("audio-bytes".utf8)))
+
+    coordinator.registerActiveDownload(
+      sessionIdentifier: session, bookID: bookID, trackKey: "track-1",
+      originalURL: url, localDestination: destination)
+
+    // Sanity: registered and present before completion.
+    XCTAssertEqual(coordinator.activeDownloads(forBookID: bookID).count, 1,
+      "Precondition: the download is tracked before it completes")
+
+    coordinator.handleBackgroundDownloadCompletion(
+      sessionIdentifier: session, downloadedFileURL: downloadedTemp, originalURL: url)
+
+    // Flush the coordinator's barrier queue with a sync read before asserting.
+    let remaining = coordinator.activeDownloads(forBookID: bookID)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path),
+      "The finalized file must be at its destination")
+    XCTAssertTrue(remaining.isEmpty,
+      "A finalized download must be pruned from activeDownloads, not left .completed")
+    XCTAssertNil(coordinator.downloadInfo(forSessionIdentifier: session),
+      "The session identifier must no longer resolve to a DownloadInfo after finalization")
+
+    try? FileManager.default.removeItem(at: dir)
+  }
 }

--- a/PalaceAudiobookToolkitTests/BearerTokenRefreshTests.swift
+++ b/PalaceAudiobookToolkitTests/BearerTokenRefreshTests.swift
@@ -82,6 +82,7 @@ final class OpenAccessDownloadTaskTokenRefreshTests: XCTestCase {
     ) -> OpenAccessDownloadTask {
         let task = OpenAccessDownloadTask(
             key: "test-track-\(UUID().uuidString.prefix(8))",
+            bookID: "test-book",
             downloadURL: URL(string: "https://distributor.example.com/content/chapter1.mp3")!,
             urlString: "https://distributor.example.com/content/chapter1.mp3",
             urlMediaType: .audioMPEG,
@@ -259,6 +260,7 @@ final class TokenScopeHostTests: XCTestCase {
         let url = URL(string: downloadURL)!
         let task = OpenAccessDownloadTask(
             key: "test-\(UUID().uuidString.prefix(8))",
+            bookID: "test-book",
             downloadURL: url,
             urlString: downloadURL,
             urlMediaType: .audioMPEG,

--- a/PalaceAudiobookToolkitTests/ChunkStallRetryTests.swift
+++ b/PalaceAudiobookToolkitTests/ChunkStallRetryTests.swift
@@ -29,6 +29,7 @@ final class ChunkStallRetryTests: XCTestCase {
     private func makeTask(token: String? = "test-token") -> OpenAccessDownloadTask {
         OpenAccessDownloadTask(
             key: "test-track-key",
+            bookID: "test-book",
             downloadURL: URL(string: "https://example.com/track.mp3")!,
             urlString: "https://example.com/track.mp3",
             urlMediaType: .audioMPEG,


### PR DESCRIPTION
Two download-durability fixes building on F1 (both SoD-reviewed: architect + qa APPROVE).

**1. Prune completed entries** (the F1 reviewers' required fast-follow). `registerActiveDownload` now populates `activeDownloads`/`download_state.json`, but nothing pruned `.completed` entries, so they accreted forever. Fix: `handleBackgroundDownloadCompletion` removes the entry after the successful `moveItem` (instead of writing `.completed`); `loadPersistedState` drops terminal (`.completed`/`.failed`) entries and those whose `localDestination` already exists on disk. In-flight `.downloading` entries (no file yet) are correctly kept for next-launch finalization — verified by both reviewers. New mutant-killing test.

**2. OpenAccess mirror of F1.** `OpenAccessDownloadTask` had the same defects F1 fixed for OverDrive: per-launch-random `remoteURL.hashValue` session id (not even book-scoped) + no `registerActiveDownload`. Fix: stable `sha256(bookID+key)` identifier + wired registration, threading `audiobookID` through the init (mirroring `OverdriveTrack`; all 4 call sites updated).

**Migration note (per qa):** the OpenAccess identifier change costs at most a one-time re-download for a download straddling the update — same benign migration as F1, no data loss.

**Not done:** a direct OpenAccess-registration unit test (covered transitively by the line-for-line F1 mirror + the coordinator prune test); device verification.