### PR TITLE
fix(download): durable per-identifier session ownership — un-freeze the reopen progress bar (F2)

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		8CF57BDA243277180053C31E /* MediaProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF57BD9243277180053C31E /* MediaProcessor.swift */; };
 		8CF57BDC2432788C0053C31E /* Data+BigEndian.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF57BDB2432788C0053C31E /* Data+BigEndian.swift */; };
 		A21FD3FA5324875CF1ED74A4 /* dune_oversubdivided_manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 8E13C49FB5EE117E6C20A818 /* dune_oversubdivided_manifest.json */; };
+		A912D4947A89BCB69017E7D2 /* OwnedSessionRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93402B672C9F80ECCB079888 /* OwnedSessionRegistryTests.swift */; };
 		A9DC9CFD220547F800D122F2 /* ErrorDescriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */; };
 		BTRF00012F1900030000001B /* BearerTokenRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BTRF00012F1900030000001A /* BearerTokenRefreshTests.swift */; };
 		C822F18BA3A94D16A7295A38 /* SpeedSliderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC08A6FDAE14519BD997FE3 /* SpeedSliderSheet.swift */; };
@@ -241,6 +242,7 @@
 		8CF57BD9243277180053C31E /* MediaProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProcessor.swift; sourceTree = "<group>"; };
 		8CF57BDB2432788C0053C31E /* Data+BigEndian.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+BigEndian.swift"; sourceTree = "<group>"; };
 		8E13C49FB5EE117E6C20A818 /* dune_oversubdivided_manifest.json */ = {isa = PBXFileReference; includeInIndex = 1; path = dune_oversubdivided_manifest.json; sourceTree = "<group>"; };
+		93402B672C9F80ECCB079888 /* OwnedSessionRegistryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OwnedSessionRegistryTests.swift; sourceTree = "<group>"; };
 		A9DC9CFC220547F800D122F2 /* ErrorDescriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDescriptions.swift; sourceTree = "<group>"; };
 		AF0BA890FAA749DAA0A58139 /* ChunkStallRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkStallRetryTests.swift; sourceTree = "<group>"; };
 		BFC08A6FDAE14519BD997FE3 /* SpeedSliderSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedSliderSheet.swift; sourceTree = "<group>"; };
@@ -437,6 +439,7 @@
 				0873ED7E066863822184CA2A /* FindawayDownloadEngineGateTests.swift */,
 				CA300CAAE5604D932B875266 /* FindawayOversubdividedTOCTests.swift */,
 				54FCA237FF72BF6A18BF3A58 /* LCPResourceLoaderColdLoadRetryTests.swift */,
+				93402B672C9F80ECCB079888 /* OwnedSessionRegistryTests.swift */,
 			);
 			path = PalaceAudiobookToolkitTests;
 			sourceTree = "<group>";
@@ -968,6 +971,7 @@
 				64EF6FD2B05B1F3409967F5B /* FindawayDownloadEngineGateTests.swift in Sources */,
 				225086F9A461257904E5F191 /* FindawayOversubdividedTOCTests.swift in Sources */,
 				064D7994823E34DB2F97DD29 /* LCPResourceLoaderColdLoadRetryTests.swift in Sources */,
+				A912D4947A89BCB69017E7D2 /* OwnedSessionRegistryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PalaceAudiobookToolkit/Core/AudiobookDownloadCoordinator.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookDownloadCoordinator.swift
@@ -24,7 +24,24 @@ public final class AudiobookDownloadCoordinator {
   
   /// Reconnected URLSessions that must be kept alive
   private var reconnectedSessions: [String: URLSession] = [:]
-  
+
+  /// Background `URLSession`s owned by the coordinator for the app's lifetime,
+  /// keyed by background-session identifier. F2: exactly ONE live background
+  /// session per identifier. The per-track download tasks (`OpenAccessDownloadTask`
+  /// / `OverdriveDownloadTask`) are recreated on every audiobook open, so if each
+  /// created its own `URLSession` with the (now-stable, F1) identifier, a reopen
+  /// spawned a SECOND live background session sharing the identifier — undefined
+  /// behavior, whose delegate callbacks stop firing, so the reopened player's
+  /// progress bar looks frozen while the original session keeps downloading.
+  /// Owning the session here (GET-OR-CREATE in `session(forIdentifier:...)`) makes
+  /// it survive player close and be reused on reopen instead of duplicated.
+  private var ownedSessions: [String: URLSession] = [:]
+
+  /// Durable router delegates for the coordinator-owned sessions, retained
+  /// alongside their session (a `URLSession` retains its delegate, but we keep an
+  /// explicit reference so the type is available for observer re-registration).
+  private var ownedSessionDelegates: [String: DurableSessionRouterDelegate] = [:]
+
   /// Active download tasks mapped by session identifier
   private var activeDownloads: [String: DownloadInfo] = [:]
   
@@ -118,7 +135,73 @@ public final class AudiobookDownloadCoordinator {
     
     downloadStatePublisher.send(.sessionReconnected(sessionIdentifier: identifier))
   }
-  
+
+  // MARK: - Coordinator-Owned Session Registry (F2)
+
+  /// Returns the coordinator-owned background `URLSession` for `identifier`,
+  /// creating it (via `configure`) on first use and REUSING the live one on
+  /// every subsequent call. This guarantees exactly one live background session
+  /// per identifier across audiobook close/reopen: the per-track download task
+  /// that outlives player close keeps its session here, and the freshly-created
+  /// task on reopen reuses it (re-registering itself as the current observer)
+  /// instead of spawning a duplicate that iOS would treat as undefined behavior.
+  ///
+  /// The router delegate that owns the session forwards its callbacks to a
+  /// swappable current observer; `registerObserver(_:forIdentifier:)` swaps it.
+  ///
+  /// - Parameters:
+  ///   - identifier: The background-session identifier (stable per book+track).
+  ///   - configure: Builds the `URLSession` on first use for this identifier.
+  ///     Called with the durable router delegate that MUST be set as the
+  ///     session's delegate. Only invoked on a cache miss.
+  /// - Returns: The live coordinator-owned session for `identifier`.
+  func session(
+    forIdentifier identifier: String,
+    configure: (DurableSessionRouterDelegate) -> URLSession
+  ) -> URLSession {
+    queue.sync(flags: .barrier) {
+      if let existing = ownedSessions[identifier] {
+        ATLog(.debug, "AudiobookDownloadCoordinator: Reusing owned session: \(identifier)")
+        return existing
+      }
+      let router = DurableSessionRouterDelegate(sessionIdentifier: identifier)
+      let session = configure(router)
+      ownedSessions[identifier] = session
+      ownedSessionDelegates[identifier] = router
+      ATLog(.debug, "AudiobookDownloadCoordinator: Created owned session: \(identifier)")
+      return session
+    }
+  }
+
+  /// Swaps the current observer the durable router for `identifier` forwards to.
+  /// Called by each download task in `downloadAsset` so the CURRENT player's
+  /// task receives progress/completion, even after a previous task (from a prior
+  /// open) was released. The router holds the observer weakly and guards the
+  /// swap with its own lock, so a released observer simply stops receiving
+  /// callbacks. Safe to call before or after `session(forIdentifier:...)`.
+  func registerObserver(_ observer: DownloadTaskObserver, forIdentifier identifier: String) {
+    let router: DurableSessionRouterDelegate? = queue.sync {
+      ownedSessionDelegates[identifier]
+    }
+    router?.setCurrentObserver(observer)
+  }
+
+  /// Invalidates and forgets the coordinator-owned session for `identifier`,
+  /// cancelling any in-flight task. Call ONLY from explicit-cancel or the
+  /// retry/token-refresh paths that deliberately tear the session down before
+  /// re-fetching — NOT on player close (F2 keeps the session alive there). The
+  /// next `session(forIdentifier:)` for this identifier then creates a fresh
+  /// session, so a stale invalidated session is never reused.
+  func discardOwnedSession(forIdentifier identifier: String) {
+    queue.sync(flags: .barrier) {
+      if let session = ownedSessions.removeValue(forKey: identifier) {
+        session.invalidateAndCancel()
+        ATLog(.debug, "AudiobookDownloadCoordinator: Discarded owned session: \(identifier)")
+      }
+      ownedSessionDelegates.removeValue(forKey: identifier)
+    }
+  }
+
   // MARK: - Download Event Handling
   
   /// Handles a background download completion.
@@ -401,6 +484,15 @@ public final class AudiobookDownloadCoordinator {
       self?.activeDownloads.removeAll()
       self?.reconnectedSessions.removeAll()
       self?.backgroundCompletionHandlers.removeAll()
+
+      // Let owned sessions drain any in-flight tasks rather than cancelling
+      // them (a hard `invalidateAndCancel` would kill a live download — the
+      // exact thing F2 must not do). `finishTasksAndInvalidate` completes
+      // outstanding tasks, then invalidates. We drop our references so the
+      // registry is empty for a fresh start / test isolation.
+      self?.ownedSessions.values.forEach { $0.finishTasksAndInvalidate() }
+      self?.ownedSessions.removeAll()
+      self?.ownedSessionDelegates.removeAll()
       
       if let url = self?.persistenceURL {
         try? FileManager.default.removeItem(at: url)
@@ -417,6 +509,115 @@ public final class AudiobookDownloadCoordinator {
     OpenAccessDownloadTask.migrateFromCachesIfNeeded()
     OverdriveDownloadTask.migrateFromCachesIfNeeded()
     ATLog(.info, "AudiobookDownloadCoordinator: Completed download migration check")
+  }
+}
+
+// MARK: - DownloadTaskObserver (F2)
+
+/// The three `URLSessionDownloadDelegate` callbacks the durable router forwards
+/// to the CURRENT download task. `DownloadTaskURLSessionDelegate` (which holds
+/// all the completion/error/retry/token-refresh/resume-data logic) conforms to
+/// this; the router calls through without duplicating any of that logic.
+///
+/// `AnyObject` so the router can hold the current observer WEAKLY — a task from
+/// a prior audiobook open must be free to deallocate, at which point it simply
+/// stops receiving callbacks (and `didFinishDownloadingTo` falls back to the
+/// coordinator's durable finalization — see the router).
+protocol DownloadTaskObserver: AnyObject {
+  func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL)
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?)
+  func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didWriteData bytesWritten: Int64,
+    totalBytesWritten: Int64,
+    totalBytesExpectedToWrite: Int64
+  )
+}
+
+// MARK: - DurableSessionRouterDelegate (F2)
+
+/// The delegate of a coordinator-owned background `URLSession`. It is created
+/// once per identifier and lives for the app's lifetime, forwarding session
+/// callbacks to whichever download task is CURRENTLY observing (the one the
+/// live player just created). Because a `URLSession`'s delegate is fixed at
+/// creation, this indirection is what lets a reopened player receive live
+/// progress on a session that a prior task created.
+///
+/// Thread-safety: `currentObserver` is read on the session's background
+/// delegate queue and written from `downloadAsset`; both go through `lock`.
+/// The observer is held weakly so a released prior task deallocates cleanly.
+final class DurableSessionRouterDelegate: NSObject, URLSessionDelegate, URLSessionDownloadDelegate {
+  private let sessionIdentifier: String
+  private let lock = NSLock()
+  private weak var currentObserver: DownloadTaskObserver?
+
+  init(sessionIdentifier: String) {
+    self.sessionIdentifier = sessionIdentifier
+    super.init()
+  }
+
+  /// Swaps the observer the router forwards to. Guarded by `lock`.
+  func setCurrentObserver(_ observer: DownloadTaskObserver) {
+    lock.lock()
+    currentObserver = observer
+    lock.unlock()
+  }
+
+  private func snapshotObserver() -> DownloadTaskObserver? {
+    lock.lock()
+    defer { lock.unlock() }
+    return currentObserver
+  }
+
+  // MARK: URLSessionDownloadDelegate
+
+  func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+    if let observer = snapshotObserver() {
+      observer.urlSession(session, downloadTask: downloadTask, didFinishDownloadingTo: location)
+      return
+    }
+
+    // REFINEMENT 1: no live observer (the download completed between player
+    // close and reopen). Dropping here would LOSE the finished file — worse
+    // than a frozen bar. Finalize durably via the F1 path, which uses the
+    // `registerActiveDownload` mapping (`downloadAsset` records it) to move the
+    // temp file to its destination. Round-2's load-prune later reaps the entry.
+    guard let originalURL = downloadTask.originalRequest?.url else {
+      ATLog(.error, "DurableSessionRouterDelegate: completed with no observer AND no original URL: \(sessionIdentifier)")
+      return
+    }
+    ATLog(.info, "DurableSessionRouterDelegate: no observer — finalizing via coordinator F1 path: \(sessionIdentifier)")
+    AudiobookDownloadCoordinator.shared.handleBackgroundDownloadCompletion(
+      sessionIdentifier: sessionIdentifier,
+      downloadedFileURL: location,
+      originalURL: originalURL
+    )
+  }
+
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    // No live observer → safe to drop: there is no player to surface the error
+    // to, and no file to finalize (a nil-error completion is handled by
+    // `didFinishDownloadingTo` above; a non-nil error has nothing to move).
+    snapshotObserver()?.urlSession(session, task: task, didCompleteWithError: error)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didWriteData bytesWritten: Int64,
+    totalBytesWritten: Int64,
+    totalBytesExpectedToWrite: Int64
+  ) {
+    // No live observer → safe to drop: progress with no player to show it is
+    // meaningless, and the reopened player re-derives progress from file state.
+    snapshotObserver()?.urlSession(
+      session,
+      downloadTask: downloadTask,
+      didWriteData: bytesWritten,
+      totalBytesWritten: totalBytesWritten,
+      totalBytesExpectedToWrite: totalBytesExpectedToWrite
+    )
   }
 }
 

--- a/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -69,6 +69,18 @@ final class OpenAccessDownloadTask: DownloadTask {
   private var session: URLSession?
   private var downloadTask: URLSessionDownloadTask?
 
+  /// Strong reference to this task's session delegate. F2: the coordinator-owned
+  /// session's delegate is the durable router, which holds the observer WEAKLY,
+  /// so the task itself must retain its `DownloadTaskURLSessionDelegate` for it
+  /// to stay alive and keep receiving forwarded callbacks. Released when the task
+  /// deallocates (player close) — at which point the router's weak ref goes nil
+  /// and the durable-completion fallback takes over.
+  private var sessionDelegate: DownloadTaskURLSessionDelegate?
+
+  /// The background-session identifier this task last created/reused, so the
+  /// cancel/retry paths can evict the coordinator-owned session for it. (F2)
+  private var backgroundSessionIdentifier: String?
+
   /// Progress should be set to 1 if the file already exists.
   /// Lazily initialized based on actual file status to avoid showing 0% for downloaded files.
   private var _downloadProgress: Float?
@@ -323,21 +335,16 @@ final class OpenAccessDownloadTask: DownloadTask {
       finalDirectory: finalURL,
       trackKey: key
     )
-
-    // Invalidate any previous session with the same identifier to prevent
-    // delegate confusion and resource leaks on retry.
-    session?.invalidateAndCancel()
-    session = URLSession(
-      configuration: config,
-      delegate: delegate,
-      delegateQueue: nil
-    )
+    // Retain the delegate strongly: the coordinator-owned session's delegate is
+    // the durable router, which holds this observer weakly. (F2)
+    sessionDelegate = delegate
 
     // Record the download with the coordinator so a background completion that
     // iOS delivers after the app is killed can be finalized to `finalURL` on
     // the next launch. Without this record, `activeDownloads` stays empty,
     // `handleBackgroundDownloadCompletion` hits its no-mapping branch, and the
     // finished temp file is dropped by the OS. Mirrors the OverDrive F1 fix.
+    // (Also the mapping the F2 no-observer durable-completion fallback relies on.)
     AudiobookDownloadCoordinator.shared.registerActiveDownload(
       sessionIdentifier: backgroundIdentifier,
       bookID: bookID,
@@ -345,6 +352,20 @@ final class OpenAccessDownloadTask: DownloadTask {
       originalURL: remoteURL,
       localDestination: finalURL
     )
+
+    // F2: GET-OR-CREATE the coordinator-owned background session. On a reopen
+    // this REUSES the live session created by the previous task (instead of
+    // spawning a duplicate with the same identifier, which iOS treats as
+    // undefined behavior and which froze the progress bar), then re-registers
+    // THIS task's delegate as the current observer so the live player sees
+    // progress. We must NOT invalidate on reuse — that would kill an in-flight
+    // background download.
+    let ownedSession = AudiobookDownloadCoordinator.shared.session(forIdentifier: backgroundIdentifier) { router in
+      URLSession(configuration: config, delegate: router, delegateQueue: nil)
+    }
+    AudiobookDownloadCoordinator.shared.registerObserver(delegate, forIdentifier: backgroundIdentifier)
+    session = ownedSession
+    backgroundSessionIdentifier = backgroundIdentifier
 
     // Check for resume data from a previous interrupted download
     if let resumeData = DownloadPersistenceStore.shared.getResumeData(forTrackKey: key) {
@@ -411,8 +432,14 @@ final class OpenAccessDownloadTask: DownloadTask {
     }
     
     downloadTask = nil
-    session?.invalidateAndCancel()
+    // F2: the session is coordinator-owned. Explicit user cancel is the one case
+    // where tearing it down is correct — evict it from the registry so a later
+    // re-fetch creates a fresh session rather than reusing an invalidated one.
+    if let identifier = backgroundSessionIdentifier {
+      AudiobookDownloadCoordinator.shared.discardOwnedSession(forIdentifier: identifier)
+    }
     session = nil
+    sessionDelegate = nil
 
     downloadProgress = 0.0
     statePublisher.send(.error(nil))
@@ -429,8 +456,14 @@ final class OpenAccessDownloadTask: DownloadTask {
     hasAttemptedTokenRefresh = true
     ATLog(.info, "OpenAccessDownloadTask: Attempting bearer token refresh for: \(key)")
 
-    session?.invalidateAndCancel()
+    // F2: evict the coordinator-owned session before re-fetching so the retry
+    // creates a fresh session (a new bearer token means new headers on the
+    // session config) instead of reusing the now-invalidated one.
+    if let identifier = backgroundSessionIdentifier {
+      AudiobookDownloadCoordinator.shared.discardOwnedSession(forIdentifier: identifier)
+    }
     session = nil
+    sessionDelegate = nil
     downloadTask = nil
 
     var request = URLRequest(url: fulfillURL)
@@ -495,8 +528,13 @@ final class OpenAccessDownloadTask: DownloadTask {
 
     ATLog(.info, "OpenAccessDownloadTask: Scheduling network-retry in \(Self.NetworkRetryDelay)s for: \(key)")
 
-    session?.invalidateAndCancel()
+    // F2: evict the coordinator-owned session before the delayed re-fetch so
+    // the retry builds a fresh session rather than reusing an invalidated one.
+    if let identifier = backgroundSessionIdentifier {
+      AudiobookDownloadCoordinator.shared.discardOwnedSession(forIdentifier: identifier)
+    }
     session = nil
+    sessionDelegate = nil
     downloadTask = nil
 
     DispatchQueue.global().asyncAfter(deadline: .now() + Self.NetworkRetryDelay) { [weak self] in
@@ -525,7 +563,7 @@ final class OpenAccessDownloadTask: DownloadTask {
 
 // MARK: - DownloadTaskURLSessionDelegate
 
-final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionDownloadDelegate {
+final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionDownloadDelegate, DownloadTaskObserver {
   private let downloadTask: DownloadTask
   private var statePublisher = PassthroughSubject<DownloadTaskState, Never>()
   private let finalURL: URL

--- a/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -564,7 +564,19 @@ final class OpenAccessDownloadTask: DownloadTask {
 // MARK: - DownloadTaskURLSessionDelegate
 
 final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionDownloadDelegate, DownloadTaskObserver {
-  private let downloadTask: DownloadTask
+  /// WEAK back-reference to the owning download task. The task retains THIS
+  /// delegate strongly (`sessionDelegate`) and the durable router retains the
+  /// delegate only weakly as its current observer — so if this were a strong
+  /// `let`, task⇄delegate would form a self-retaining cycle that never breaks on
+  /// player close (nil'd only on cancel/retry). That cycle would keep the
+  /// delegate alive, so the router's weak `currentObserver` would never nil and
+  /// the F2 no-observer durable-completion fallback would be unreachable via the
+  /// close path. Weak here breaks the cycle: on player close the audiobook graph
+  /// releases the task → this delegate deallocs → `router.currentObserver` nils →
+  /// a completion delivered while closed flows through Refinement 1. While a
+  /// download is genuinely active the audiobook graph keeps the task alive, so
+  /// this reference is non-nil for every callback that needs it.
+  private weak var downloadTask: DownloadTask?
   private var statePublisher = PassthroughSubject<DownloadTaskState, Never>()
   private let finalURL: URL
   private let trackKey: String
@@ -593,7 +605,7 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
 
   func urlSession(_: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
     guard let httpResponse = downloadTask.response as? HTTPURLResponse else {
-      ATLog(.error, "Response could not be cast to HTTPURLResponse: \(self.downloadTask.key)")
+      ATLog(.error, "Response could not be cast to HTTPURLResponse: \(self.downloadTask?.key ?? self.trackKey)")
       statePublisher.send(.error(nil))
       return
     }
@@ -619,22 +631,24 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
               ATLog(.error, "Could not remove original downloaded file at \(location.absoluteString) Error: \(error)")
             }
           }
-          self.downloadTask.downloadProgress = 1.0
+          self.downloadTask?.downloadProgress = 1.0
           self.statePublisher.send(.completed)
-          NotificationCenter.default.post(name: OpenAccessTaskCompleteNotification, object: self.downloadTask)
+          if let task = self.downloadTask {
+            NotificationCenter.default.post(name: OpenAccessTaskCompleteNotification, object: task)
+          }
         } else {
-          self.downloadTask.downloadProgress = 0.0
+          self.downloadTask?.downloadProgress = 0.0
           self.statePublisher.send(.error(nil))
         }
       }
     } else {
       ATLog(.error, "Download Task failed with server response: \n\(httpResponse.description)")
-      self.downloadTask.downloadProgress = 0.0
+      self.downloadTask?.downloadProgress = 0.0
 
       if httpResponse.statusCode == 401,
          let oaTask = self.downloadTask as? OpenAccessDownloadTask,
          oaTask.attemptTokenRefreshAndRetry() {
-        ATLog(.info, "DownloadTaskDelegate: 401 received, token refresh initiated for: \(self.downloadTask.key)")
+        ATLog(.info, "DownloadTaskDelegate: 401 received, token refresh initiated for: \(self.downloadTask?.key ?? self.trackKey)")
         return
       }
 
@@ -643,7 +657,7 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
       // a DDoS pattern against the content server.
       if httpResponse.statusCode == 403,
          let oaTask = self.downloadTask as? OpenAccessDownloadTask {
-        ATLog(.error, "DownloadTaskDelegate: 403 Forbidden for: \(self.downloadTask.key) — will not retry")
+        ATLog(.error, "DownloadTaskDelegate: 403 Forbidden for: \(self.downloadTask?.key ?? self.trackKey) — will not retry")
         oaTask.isForbidden = true
 
         // Publish a typed error with HTTP status + URL context so the player
@@ -657,7 +671,7 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
           userInfo: [
             NSLocalizedDescriptionKey: OpenAccessPlayerError.contentForbidden.errorDescription(),
             "httpStatusCode": httpResponse.statusCode,
-            "trackKey": self.downloadTask.key,
+            "trackKey": self.trackKey,
             "url": httpResponse.url?.absoluteString ?? ""
           ]
         )
@@ -681,7 +695,7 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
           userInfo: [
             NSLocalizedDescriptionKey: "Server returned HTTP \(httpResponse.statusCode)",
             "httpStatusCode": httpResponse.statusCode,
-            "trackKey": self.downloadTask.key,
+            "trackKey": self.trackKey,
             "url": httpResponse.url?.absoluteString ?? ""
           ]
         )
@@ -697,8 +711,8 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
       return
     }
 
-    ATLog(.error, "No file URL or response from download task: \(downloadTask.key).", error: error)
-    
+    ATLog(.error, "No file URL or response from download task: \(self.downloadTask?.key ?? self.trackKey).", error: error)
+
     // Try to save resume data for later recovery
     let nsError = error as NSError
     if let resumeData = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data {
@@ -721,7 +735,7 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
         // successful completion in `didFinishDownloadingTo`.
         if let oaTask = self.downloadTask as? OpenAccessDownloadTask,
            oaTask.attemptNetworkRetryAfterTransientError() {
-          ATLog(.info, "DownloadTaskDelegate: transient network error (\(code)) for \(self.downloadTask.key) — retry scheduled, suppressing terminal error")
+          ATLog(.info, "DownloadTaskDelegate: transient network error (\(code)) for \(self.downloadTask?.key ?? self.trackKey) — retry scheduled, suppressing terminal error")
           return
         }
         let networkLossError = NSError(
@@ -755,6 +769,12 @@ final class DownloadTaskURLSessionDelegate: NSObject, URLSessionDelegate, URLSes
       guard let self = self else {
         return
       }
+
+      // If the owning task has been released (player closed mid-download), skip
+      // the progress update — there is no live player to show it, and the
+      // reopened player re-derives progress from file state. The download itself
+      // continues on the coordinator-owned session regardless.
+      guard let downloadTask = self.downloadTask else { return }
 
       if totalBytesExpectedToWrite == NSURLSessionTransferSizeUnknown || totalBytesExpectedToWrite == 0 {
         downloadTask.downloadProgress = 0.0

--- a/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -559,6 +559,16 @@ final class OpenAccessDownloadTask: DownloadTask {
   var hasUsedNetworkRetry: Bool {
     hasAttemptedNetworkRetry
   }
+
+  /// Test seam — installs `delegate` as this task's strongly-held session
+  /// delegate, reproducing the exact ownership `downloadAsset` sets up
+  /// (`sessionDelegate = delegate`). Lets the retain-cycle test assert that
+  /// task⇄delegate is NOT a cycle: with the delegate's back-reference weak,
+  /// dropping external strong refs must dealloc both. If the back-reference
+  /// regressed to strong, neither would dealloc and the test would fail.
+  func installSessionDelegateForTesting(_ delegate: DownloadTaskURLSessionDelegate) {
+    sessionDelegate = delegate
+  }
 }
 
 // MARK: - DownloadTaskURLSessionDelegate

--- a/PalaceAudiobookToolkit/Network/OverdriveDownloadTask.swift
+++ b/PalaceAudiobookToolkit/Network/OverdriveDownloadTask.swift
@@ -21,6 +21,16 @@ final class OverdriveDownloadTask: DownloadTask {
 
   private var urlSession: URLSession?
 
+  /// Strong reference to this task's session delegate. F2: the coordinator-owned
+  /// session's delegate is the durable router, which holds the observer WEAKLY,
+  /// so the task must retain its `DownloadTaskURLSessionDelegate` for it to stay
+  /// alive and keep receiving forwarded callbacks.
+  private var sessionDelegate: DownloadTaskURLSessionDelegate?
+
+  /// The background-session identifier this task last created/reused, so the
+  /// cancel path can evict the coordinator-owned session for it. (F2)
+  private var backgroundSessionIdentifier: String?
+
   var downloadProgress: Float = 0 {
     didSet {
       DispatchQueue.main.async { [weak self] in
@@ -158,18 +168,16 @@ final class OverdriveDownloadTask: DownloadTask {
       finalDirectory: finalURL,
       trackKey: key
     )
-
-    urlSession = URLSession(
-      configuration: config,
-      delegate: delegate,
-      delegateQueue: nil
-    )
+    // Retain the delegate strongly: the coordinator-owned session's delegate is
+    // the durable router, which holds this observer weakly. (F2)
+    sessionDelegate = delegate
 
     // Record the download with the coordinator so a background completion that
     // iOS delivers after the app is killed can be finalized to `finalURL` on the
     // next launch. Without this record, `activeDownloads` stays empty,
     // `handleBackgroundDownloadCompletion` hits its no-mapping branch, and the
     // finished temp file is dropped by the OS. (PP-4800 root-cause fix — F1.)
+    // (Also the mapping the F2 no-observer durable-completion fallback relies on.)
     AudiobookDownloadCoordinator.shared.registerActiveDownload(
       sessionIdentifier: backgroundIdentifier,
       bookID: bookID,
@@ -177,6 +185,18 @@ final class OverdriveDownloadTask: DownloadTask {
       originalURL: remoteURL,
       localDestination: finalURL
     )
+
+    // F2: GET-OR-CREATE the coordinator-owned background session. On a reopen
+    // this REUSES the live session created by the previous task instead of
+    // spawning a duplicate with the same (F1-stable) identifier — which iOS
+    // treats as undefined behavior and which froze the reopened progress bar.
+    // Re-register THIS task's delegate as the current observer so the live
+    // player sees progress. No invalidate on reuse (would kill the download).
+    urlSession = AudiobookDownloadCoordinator.shared.session(forIdentifier: backgroundIdentifier) { router in
+      URLSession(configuration: config, delegate: router, delegateQueue: nil)
+    }
+    AudiobookDownloadCoordinator.shared.registerObserver(delegate, forIdentifier: backgroundIdentifier)
+    backgroundSessionIdentifier = backgroundIdentifier
 
     // Check for resume data from a previous interrupted download
     if let resumeData = DownloadPersistenceStore.shared.getResumeData(forTrackKey: key) {
@@ -224,8 +244,14 @@ final class OverdriveDownloadTask: DownloadTask {
       }
     }
     
-    urlSession?.invalidateAndCancel()
+    // F2: the session is coordinator-owned. Explicit user cancel is the one case
+    // where tearing it down is correct — evict it so a later re-fetch creates a
+    // fresh session rather than reusing an invalidated one.
+    if let identifier = backgroundSessionIdentifier {
+      AudiobookDownloadCoordinator.shared.discardOwnedSession(forIdentifier: identifier)
+    }
     urlSession = nil
+    sessionDelegate = nil
 
     downloadProgress = 0.0
     statePublisher.send(.error(nil))

--- a/PalaceAudiobookToolkitTests/OwnedSessionRegistryTests.swift
+++ b/PalaceAudiobookToolkitTests/OwnedSessionRegistryTests.swift
@@ -1,0 +1,188 @@
+//
+//  OwnedSessionRegistryTests.swift
+//  PalaceAudiobookToolkitTests
+//
+//  F2: the coordinator owns exactly ONE background URLSession per identifier
+//  for the app's lifetime, so a reopened audiobook REUSES the live session a
+//  prior download task created instead of spawning a duplicate with the same
+//  (F1-stable) identifier — the duplicate is what iOS treats as undefined
+//  behavior and what froze the reopened progress bar.
+//
+//  These tests pin the registry's GET-OR-CREATE + eviction contract (the part
+//  that is unit-testable). The background-session DELEGATE lifecycle itself
+//  (iOS delivering didWriteData / didFinishDownloadingTo across app suspension)
+//  is NOT exercisable under XCTest and is covered by the on-device checklist.
+//
+//  Copyright (c) 2026 The Palace Project. All rights reserved.
+//
+
+import XCTest
+@testable import PalaceAudiobookToolkit
+
+final class OwnedSessionRegistryTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    AudiobookDownloadCoordinator.shared.clearAllState()
+  }
+
+  override func tearDown() {
+    AudiobookDownloadCoordinator.shared.clearAllState()
+    super.tearDown()
+  }
+
+  /// A plain (non-background) URLSession stands in for the real background
+  /// session in these registry tests: the coordinator only stores and returns
+  /// the instance it is handed, so identity is all that matters here. Using a
+  /// real background session in a unit test is both unnecessary and flaky.
+  private func makeSession(_ router: DurableSessionRouterDelegate) -> URLSession {
+    URLSession(configuration: .default, delegate: router, delegateQueue: nil)
+  }
+
+  // MARK: - GET-OR-CREATE
+
+  /// Same identifier -> same URLSession instance, and `configure` runs exactly
+  /// ONCE. This is the core F2 guarantee: the reopened task reuses the live
+  /// session rather than creating a second one under the shared identifier.
+  func testSession_sameIdentifier_returnsSameInstanceAndConfiguresOnce() {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let identifier = "app.openAccessBackgroundIdentifier.reuse-same"
+
+    var configureCount = 0
+    let first = coordinator.session(forIdentifier: identifier) { router in
+      configureCount += 1
+      return self.makeSession(router)
+    }
+    let second = coordinator.session(forIdentifier: identifier) { router in
+      configureCount += 1
+      return self.makeSession(router)
+    }
+
+    XCTAssertTrue(first === second,
+      "A repeated identifier must return the identical live session, not a duplicate")
+    XCTAssertEqual(configureCount, 1,
+      "The session must be created once and reused — a second create means a duplicate background session")
+
+    first.invalidateAndCancel()
+  }
+
+  /// Distinct identifiers -> distinct URLSession instances, one `configure` per
+  /// identifier. Guards against a registry that collapses different tracks/books
+  /// onto one session.
+  func testSession_distinctIdentifiers_returnDistinctInstances() {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let idA = "app.openAccessBackgroundIdentifier.track-A"
+    let idB = "app.openAccessBackgroundIdentifier.track-B"
+
+    var configureCount = 0
+    let a = coordinator.session(forIdentifier: idA) { router in
+      configureCount += 1
+      return self.makeSession(router)
+    }
+    let b = coordinator.session(forIdentifier: idB) { router in
+      configureCount += 1
+      return self.makeSession(router)
+    }
+
+    XCTAssertFalse(a === b, "Different identifiers must map to different sessions")
+    XCTAssertEqual(configureCount, 2, "Each distinct identifier configures its own session")
+
+    a.invalidateAndCancel()
+    b.invalidateAndCancel()
+  }
+
+  // MARK: - Eviction (cancel / retry paths)
+
+  /// After `discardOwnedSession`, the next `session(forIdentifier:)` for the
+  /// same identifier CREATES A FRESH session (configure runs again) — a prior
+  /// invalidated session is never handed back out. This is what makes the
+  /// explicit-cancel and token-refresh/network-retry paths safe: they evict,
+  /// then re-fetch builds a new session.
+  func testDiscard_thenSession_createsFreshInstance() {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let identifier = "app.overdriveBackgroundIdentifier.evict-refetch"
+
+    var configureCount = 0
+    let original = coordinator.session(forIdentifier: identifier) { router in
+      configureCount += 1
+      return self.makeSession(router)
+    }
+
+    coordinator.discardOwnedSession(forIdentifier: identifier)
+
+    let replacement = coordinator.session(forIdentifier: identifier) { router in
+      configureCount += 1
+      return self.makeSession(router)
+    }
+
+    XCTAssertFalse(original === replacement,
+      "After eviction, a re-fetch must build a NEW session — reusing the invalidated one would silently drop callbacks")
+    XCTAssertEqual(configureCount, 2,
+      "Eviction must clear the cache so the next fetch reconfigures")
+
+    replacement.invalidateAndCancel()
+  }
+
+  /// Discarding an identifier that was never created is a no-op (no crash, no
+  /// spurious state). Exercises the cancel path firing before any download
+  /// started for that task.
+  func testDiscard_unknownIdentifier_isNoOp() {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    coordinator.discardOwnedSession(forIdentifier: "never-created")
+
+    var configured = false
+    let session = coordinator.session(forIdentifier: "never-created") { router in
+      configured = true
+      return self.makeSession(router)
+    }
+    XCTAssertTrue(configured,
+      "Discarding a never-created identifier must not leave a phantom entry that suppresses the real create")
+    session.invalidateAndCancel()
+  }
+
+  // MARK: - Observer swap (thread-safety smoke)
+
+  /// `registerObserver` for an identifier with a live session must not crash and
+  /// must be safe to call repeatedly (each open re-registers). Concurrent swaps
+  /// exercise the router's lock — a data race here would trip TSan / crash.
+  func testRegisterObserver_concurrentSwaps_areSafe() {
+    let coordinator = AudiobookDownloadCoordinator.shared
+    let identifier = "app.openAccessBackgroundIdentifier.observer-swap"
+
+    let session = coordinator.session(forIdentifier: identifier) { router in
+      self.makeSession(router)
+    }
+
+    // Keep strong refs so the weak observer isn't collected mid-loop; the point
+    // is that concurrent setCurrentObserver calls don't race.
+    let observers = (0..<8).map { _ in RecordingObserver() }
+    let group = DispatchGroup()
+    for observer in observers {
+      DispatchQueue.global().async(group: group) {
+        for _ in 0..<50 {
+          coordinator.registerObserver(observer, forIdentifier: identifier)
+        }
+      }
+    }
+    let finished = group.wait(timeout: .now() + 5)
+    XCTAssertEqual(finished, .success, "Concurrent observer swaps must complete without deadlock")
+
+    session.invalidateAndCancel()
+  }
+}
+
+// MARK: - Test double
+
+/// Minimal `DownloadTaskObserver` that records nothing — used only to have a
+/// concrete AnyObject the router can hold weakly during the swap-safety test.
+private final class RecordingObserver: DownloadTaskObserver {
+  func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {}
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {}
+  func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didWriteData bytesWritten: Int64,
+    totalBytesWritten: Int64,
+    totalBytesExpectedToWrite: Int64
+  ) {}
+}

--- a/PalaceAudiobookToolkitTests/OwnedSessionRegistryTests.swift
+++ b/PalaceAudiobookToolkitTests/OwnedSessionRegistryTests.swift
@@ -140,6 +140,63 @@ final class OwnedSessionRegistryTests: XCTestCase {
     session.invalidateAndCancel()
   }
 
+  // MARK: - Retain cycle (architect SoD blocker — the mutant-killer)
+
+  /// F2 makes a download task strongly retain its `DownloadTaskURLSessionDelegate`
+  /// (`sessionDelegate`), and the delegate holds the task back. If that back-ref
+  /// were strong, task⇄delegate would be a self-retaining cycle that never breaks
+  /// on player close — leaking the pair AND keeping the router's weak observer
+  /// alive, which would make the no-observer durable-completion fallback
+  /// unreachable via close. The back-ref is `weak`, so dropping every external
+  /// strong ref must dealloc BOTH. This asserts exactly that.
+  ///
+  /// Mutation coverage: flip the delegate's `weak var downloadTask` back to a
+  /// strong `let`/`var` and this test fails (the sentinels stay non-nil).
+  func testTaskAndDelegate_deallocateWhenExternalRefsDropped_noRetainCycle() {
+    weak var weakTask: OpenAccessDownloadTask?
+    weak var weakDelegate: DownloadTaskURLSessionDelegate?
+
+    autoreleasepool {
+      let url = URL(string: "https://example.com/chapter.mp3")!
+      let dest = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("cycle-dest.mp3")
+
+      let task = OpenAccessDownloadTask(
+        key: "cycle-track",
+        bookID: "cycle-book",
+        downloadURL: url,
+        urlString: url.absoluteString,
+        urlMediaType: .audioMPEG,
+        alternateLinks: nil,
+        feedbooksProfile: nil,
+        token: nil
+      )
+      let delegate = DownloadTaskURLSessionDelegate(
+        downloadTask: task,
+        statePublisher: task.statePublisher,
+        finalDirectory: dest,
+        trackKey: task.key
+      )
+      // Reproduce production ownership: the task strongly retains its delegate,
+      // exactly as `downloadAsset` does. The delegate's back-ref to the task is
+      // the thing under test.
+      task.installSessionDelegateForTesting(delegate)
+
+      weakTask = task
+      weakDelegate = delegate
+
+      // Sanity: both alive while the local strong refs exist.
+      XCTAssertNotNil(weakTask)
+      XCTAssertNotNil(weakDelegate)
+    }
+
+    // External strong refs (the locals) are gone. With a weak back-reference the
+    // cycle is broken, so both must have deallocated.
+    XCTAssertNil(weakTask,
+      "The download task must deallocate when external refs drop — a strong delegate back-ref would leak it")
+    XCTAssertNil(weakDelegate,
+      "The session delegate must deallocate with its task — otherwise the router's weak observer never nils and Refinement 1 is unreachable on close")
+  }
+
   // MARK: - Observer swap (thread-safety smoke)
 
   /// `registerObserver` for an identifier with a live session must not crash and


### PR DESCRIPTION
Fixes the user-observed "download progress bar freezes when you exit and reopen a downloading audiobook."

**Root cause:** each open builds new download-task instances, each creating a background `URLSession` keyed by the F1-stable `sha256(bookID+key)`. The `session→delegate→task` chain outlived player close, so on reopen a *second* live session shared the identifier (iOS UB) — its callbacks didn't fire, the reopened bar showed only completed-track count (frozen), while the original session kept downloading into an orphaned publisher.

**Fix:** a coordinator-owned per-identifier session registry (`session(forIdentifier:configure:)` GET-OR-CREATE into `ownedSessions`) + a `DurableSessionRouterDelegate` that owns the session's delegate slot and forwards to a swappable **weak** current observer. Each `downloadAsset` GET-OR-CREATEs the session and registers its `DownloadTaskURLSessionDelegate` as the observer (whose completion/error/retry logic is unchanged). Refinements: (1) no-observer completion finalizes durably via the F1 `handleBackgroundDownloadCompletion` path (no dropped file); (2) `NSLock` guards the observer swap; (3) the `Task⇄Delegate` retain cycle is broken (`weak downloadTask`) so the delegate is genuinely released on close and the router's weak ref nils.

**SoD:** qa APPROVE; architect REQUEST-CHANGES → fixed (the retain cycle) → re-review. Tests: coordinator registry (reuse/discard) + a task/delegate deallocation mutant-killer.

**Follow-ups (round-3, non-blocking, both reviewers agree):** discard owned sessions on normal completion (accretion) + a bounded-registry `count` seam; sequence OverDrive `cancel()` resume-data save before the discard.

**On-device verification is a required QA gate** (background-`URLSession` lifecycle is untestable): open mid-download → close → reopen → bar advances (not frozen); download-while-closed still finalizes; kill-mid-download still finalizes (F1).