### PR TITLE
fix(nowplaying): harden lock-screen artwork handler against off-main block-destroy crash

### DIFF
--- a/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
+++ b/PalaceAudiobookToolkit/UI/AudiobookPlaybackModel.swift
@@ -612,8 +612,20 @@ public class AudiobookPlaybackModel: ObservableObject {
   private func updateLockScreenCoverArtwork(image: UIImage?) {
     DispatchQueue.main.async {
       if let image = image {
-        let itemArtwork = MPMediaItemArtwork(boundsSize: image.size) { _ in
-          image
+        // MediaPlayer invokes AND tears down this request handler on its OWN
+        // background queue (it rasterizes lazily via
+        // `-[MPMediaItemArtwork jpegDataWithSize:]` when building the
+        // Now-Playing / lock-screen info). A plain, non-`@Sendable` handler
+        // that closes over `image` gets its captured `UIImage` released from
+        // that off-main block-destroy, racing the main-thread lifetime of the
+        // same image — which trapped in `block_destroy_helper` (Crashlytics
+        // e672637, EXC_BREAKPOINT). Capturing an immutable local and marking
+        // the handler `@Sendable` makes the block's captured state provably
+        // safe to build/destroy off-main. Mirrors the app-side
+        // NowPlayingCoordinator fix (Palace #1218).
+        let artworkImage = image
+        let itemArtwork = MPMediaItemArtwork(boundsSize: image.size) { @Sendable _ in
+          artworkImage
         }
 
         var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()


### PR DESCRIPTION
## What

`AudiobookPlaybackModel.updateLockScreenCoverArtwork` built its `MPMediaItemArtwork` with a plain (non-`@Sendable`) request handler that closes over `image`:

```swift
let itemArtwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
```

MediaPlayer invokes **and destroys** that handler on its own background queue (it rasterizes lazily via `-[MPMediaItemArtwork jpegDataWithSize:]` when building the Now-Playing / lock-screen info). The block-destroy released the captured `UIImage` off-main, racing the image's main-thread lifetime → **`block_destroy_helper` EXC_BREAKPOINT**.

## Crash

Crashlytics **`e672637`** — `[PalaceAudiobookToolkit] block_destroy_helper.46`, FATAL, on Palace 3.2.0 audiobook opens.

## Fix

Capture an immutable local and mark the handler `@Sendable`, so the block's captured state is provably safe to build/tear-down off the main thread. This **mirrors the app-side `NowPlayingCoordinator` fix (Palace #1218)**, which resolved the *identical* crash on the app's own now-playing artwork path — zero recurrence on 3.3.0 builds since.

## Verification

- Toolkit CI is the build gate.
- Runtime confirmation is via Crashlytics (zero new `e672637` on builds carrying this fix) — the trap can't be reproduced on demand (needs MediaPlayer to rasterize + release within the racing window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)