### PR TITLE
chore: bump Readium swift-toolkit 3.9.0 → 3.11.0

### DIFF
--- a/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/PalaceAudiobookToolkit.xcodeproj/project.pbxproj
@@ -1292,7 +1292,7 @@
 			repositoryURL = "https://github.com/readium/swift-toolkit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 3.9.0;
+				version = 3.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PalaceAudiobookToolkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PalaceAudiobookToolkit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -51,17 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "392dd6058624d9f6c5b4c769d165ddd8c7293394",
-        "version" : "0.15.4"
-      }
-    },
-    {
-      "identity" : "swift-toolchain-sqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
-      "state" : {
-        "revision" : "b626d3002773b1a1304166643e7f118f724b2132",
-        "version" : "1.0.4"
+        "revision" : "964c300fb0736699ce945c9edb56ecd62eba27a3",
+        "version" : "0.16.0"
       }
     },
     {
@@ -69,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/readium/swift-toolkit.git",
       "state" : {
-        "revision" : "de07026e9f825a5791f27a7ac4cd6bb1a784ab8d",
-        "version" : "3.9.0"
+        "revision" : "d82f44f4f05d87add9e22a8b75abbd61dce745dd",
+        "version" : "3.11.0"
       }
     },
     {


### PR DESCRIPTION
## What

Bump the Readium swift-toolkit dependency from **3.9.0 → 3.11.0** (pbxproj `exactVersion` + regenerated `Package.resolved`, revision `d82f44f4f0`).

## Why

Companion to the ThePalaceProject/ios-core parent bump (PP-4848). This toolkit is a **second swift-toolkit consumer** — when ios-core builds it as a subproject, both SPM graphs share one resolution, so the two `exactVersion` pins must agree. With the app on 3.11.0 and this toolkit still on 3.9.0, SPM resolution fails (`swift-toolkit 3.9.0 cannot be used because root depends on 3.11.0`).

## Scope

- The toolkit imports **only `ReadiumShared`**. The 3.10/3.11 breaking API changes (`LCPClient.getSupportedLCPProfileURIs()`, `LCPPassphraseRepository.addPassphrase` signature, LCP device-ID→Keychain) all live in the **app** target, not here — so **no source changes** are needed in this repo.
- Pin + `Package.resolved` only.

## Verified

Built as part of the DRM `Palace` target from ios-core (`feat/pp-4848-readium-3.11.0`) with this toolkit at 3.11.0 — **BUILD SUCCEEDED**, no source changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
