### PR TITLE
fix(nowplaying): drive lock-screen heartbeat off the player clock, not a runloop timer

### DIFF
--- a/PalaceAudiobookToolkit/Core/AudiobookManager.swift
+++ b/PalaceAudiobookToolkit/Core/AudiobookManager.swift
@@ -323,6 +323,11 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
 
   private var chapterMonitorTimer: Cancellable?
 
+  /// Last time the player-driven lock-screen heartbeat wrote now-playing info.
+  /// Rate-limits `setupNowPlayingHeartbeat`'s `positionPublisher` sink (which
+  /// fires ~4×/s) to a lock-screen-appropriate cadence. HelpSpot 17865.
+  private var lastNowPlayingHeartbeat: Date = .distantPast
+
   // MARK: - Initialization
 
   public init(
@@ -343,6 +348,7 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
     setupBindings()
     subscribeToPlayer()
     setupNowPlayingInfoTimer()
+    setupNowPlayingHeartbeat()
     setupChapterMonitorTimer()
     subscribeToMediaControlCommands()
     calculateOverallDownloadProgress()
@@ -493,6 +499,38 @@ public final class DefaultAudiobookManager: NSObject, AudiobookManager {
   }
 
   // MARK: - Now Playing Info
+
+  /// Player-clock lock-screen heartbeat (HelpSpot 17865 / Crashlytics code 403).
+  ///
+  /// `setupNowPlayingInfoTimer` refreshes MPNowPlayingInfoCenter from a
+  /// main-runloop `Timer.publish(in: .common)`. iOS coalesces and suspends such
+  /// timers during long screen-locked background playback, so the lock screen
+  /// goes dry >30s while audio keeps playing and the ios-core NowPlayingCoordinator
+  /// logs the dry-stream (~23k events through 3.2.3).
+  ///
+  /// `positionPublisher` is fed by the player's AVPlayer periodic-time observer,
+  /// which the OS guarantees to fire while audio is actually playing — including
+  /// backgrounded and locked, because it is driven by the playback clock rather
+  /// than the runloop. Drive the lock-screen writer off it too, so the heartbeat
+  /// survives runloop coalescing. Rate-limited to a lock-screen cadence via
+  /// `lastNowPlayingHeartbeat` (the stream itself fires ~4×/s).
+  ///
+  /// Lock-screen only: the in-app slider already subscribes to `positionPublisher`
+  /// (AudiobookPlaybackModel), so this deliberately does NOT re-publish
+  /// `.positionUpdated` — that avoids perturbing the slider path and the
+  /// foreground resume-jump fix in `setupAppStateObserver`.
+  private func setupNowPlayingHeartbeat() {
+    audiobook.player.positionPublisher
+      .receive(on: RunLoop.main)
+      .sink { [weak self] position in
+        guard let self, self.audiobook.player.isPlaying else { return }
+        let now = Date()
+        guard now.timeIntervalSince(self.lastNowPlayingHeartbeat) >= 2.0 else { return }
+        self.lastNowPlayingHeartbeat = now
+        self.updateNowPlayingInfo(position)
+      }
+      .store(in: &cancellables)
+  }
 
   private func setupNowPlayingInfoTimer() {
     timer?.cancel()

--- a/PalaceAudiobookToolkitTests/AudiobookAccessibilityAnnouncementCenterTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookAccessibilityAnnouncementCenterTests.swift
@@ -11,36 +11,38 @@ import XCTest
 final class AudiobookAccessibilityAnnouncementCenterTests: XCTestCase {
 
   /// Regression test for PP-3594: VoiceOver should announce audiobook download progress at throttled intervals.
-  func testPP3594_audiobookProgress_throttlesAnnouncements() {
+  func testPP3594_intermediateDownloadProgress_isSuppressed_butStartStillAnnounces() {
+    // Contract (commit 0d739944 "Silence intermediate download progress
+    // VoiceOver announcements"): intermediate progress must NOT interrupt a
+    // VoiceOver listener; only start/completion/failure announce. The previous
+    // form of this test asserted per-step progress announcements, which the
+    // suppression change deliberately removed — it was stale and failing.
     var announcements: [String] = []
-    let expectedCount = 2
-    let expectation = expectation(description: "Progress announcements posted")
-    expectation.expectedFulfillmentCount = expectedCount
-
     let announcer = AudiobookAccessibilityAnnouncementCenter(
-      postHandler: { _, message in
-        announcements.append(message)
-        expectation.fulfill()
-      },
+      postHandler: { _, message in announcements.append(message) },
       isVoiceOverRunning: { true },
       progressStep: 20
     )
 
-    announcer.announceDownloadProgress(title: "Sample Audiobook", identifier: "audio-1", progress: 0.10)
-    announcer.announceDownloadProgress(title: "Sample Audiobook", identifier: "audio-1", progress: 0.20)
-    announcer.announceDownloadProgress(title: "Sample Audiobook", identifier: "audio-1", progress: 0.25)
-    announcer.announceDownloadProgress(title: "Sample Audiobook", identifier: "audio-1", progress: 0.40)
-    announcer.announceDownloadProgress(title: "Sample Audiobook", identifier: "audio-1", progress: 1.00)
+    // Positive control: start DOES announce, proving the post path is live
+    // (so an empty result below means suppression, not a dead announcer).
+    announcer.announceDownloadStarted(title: "Sample Audiobook")
 
-    wait(for: [expectation], timeout: 1.0)
+    // Every intermediate progress tick must be silent.
+    for progress in [0.10, 0.20, 0.25, 0.40, 1.00] {
+      announcer.announceDownloadProgress(title: "Sample Audiobook", identifier: "audio-1", progress: progress)
+    }
 
-    XCTAssertEqual(
-      announcements,
-      [
-        "Download 20 percent complete for Sample Audiobook.",
-        "Download 40 percent complete for Sample Audiobook."
-      ]
-    )
+    // `announce` hops to the main queue; drain it so any erroneous progress
+    // post would have landed before we assert.
+    let drained = expectation(description: "main queue drained")
+    DispatchQueue.main.async { drained.fulfill() }
+    wait(for: [drained], timeout: 1.0)
+
+    XCTAssertEqual(announcements.count, 1,
+      "Only the start announcement should post; intermediate progress is suppressed.")
+    XCTAssertFalse(announcements.contains { $0.localizedCaseInsensitiveContains("percent") },
+      "No intermediate progress (percent) announcement should be posted.")
   }
 
   /// Regression test for PP-3594: VoiceOver announcements should not fire when VoiceOver is off.

--- a/PalaceAudiobookToolkitTests/AudiobookManagerLifecycleTests.swift
+++ b/PalaceAudiobookToolkitTests/AudiobookManagerLifecycleTests.swift
@@ -24,6 +24,7 @@
 //
 
 import Combine
+import MediaPlayer
 import XCTest
 @testable import PalaceAudiobookToolkit
 
@@ -167,5 +168,62 @@ final class AudiobookManagerLifecycleTests: XCTestCase {
   //    and skip this test in the toolkit — main-repo coverage compensates."
   func testNowPlayingInfoWrite_isWrappedInBackgroundTask() throws {
     throw XCTSkip("Skipped per contract: toolkit lacks UIApplication shim; main-repo NowPlayingCoordinatorBackgroundTests covers writer-side beginBackgroundTask discipline.")
+  }
+
+  // MARK: - Test 4: player positionPublisher drives the lock screen independently
+  //
+  // HelpSpot 17865 residual (Crashlytics code 403, "NowPlayingCoordinator dry
+  // while isPlaying"): the wall-clock `timer` that refreshes MPNowPlayingInfoCenter
+  // is a main-runloop `.common` timer. iOS coalesces/suspends it during long
+  // screen-locked background playback, so the lock screen goes stale >30s and
+  // the ios-core watchdog logs the dry-stream (~23k events through 3.2.3).
+  //
+  // The player's AVPlayer periodic-time observer (`positionPublisher`) is
+  // OS-guaranteed to fire while audio is actually playing — including
+  // backgrounded/locked — because it is driven by the playback clock, not the
+  // runloop. This test pins that the manager ALSO drives the lock-screen writer
+  // off `positionPublisher`, so a position emission refreshes now-playing even
+  // when the wall-clock timer is not the source (the background case, modeled
+  // here by cancelling `timer` before emitting).
+  func testPositionPublisher_refreshesLockScreen_whenWallClockTimerSilent() throws {
+    let (manager, player) = try makeManager()
+
+    let firstTrack = manager.tableOfContents.allTracks.first
+    XCTAssertNotNil(firstTrack, "Test fixture must have at least one track.")
+    guard let track = firstTrack else { return }
+
+    // Model the background case: the coalescible wall-clock timer is not firing,
+    // so it cannot be the source of any lock-screen refresh.
+    manager.timer?.cancel()
+
+    // Clear the process-wide now-playing info so a non-nil read afterwards can
+    // only have come from the heartbeat we are exercising.
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+
+    let position = TrackPosition(track: track, timestamp: 42.0, tracks: manager.tableOfContents.tracks)
+    player.isPlaying = true
+    player.currentTrackPosition = position
+
+    // The heartbeat delivers on the main runloop; give it a tick to settle.
+    let settled = XCTestExpectation(description: "Heartbeat settled")
+    player._emitPosition(position)
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { settled.fulfill() }
+    wait(for: [settled], timeout: 2.0)
+
+    let info = MPNowPlayingInfoCenter.default().nowPlayingInfo
+    XCTAssertNotNil(
+      info,
+      "positionPublisher emission while playing must refresh MPNowPlayingInfoCenter even with the wall-clock timer cancelled — the lock-screen heartbeat must not depend solely on the coalescible main-runloop timer. HelpSpot 17865 / code 403."
+    )
+
+    let expectedElapsed = (try? manager.tableOfContents.chapterOffset(for: position))
+    if let expectedElapsed, let actualElapsed = info?[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double {
+      XCTAssertEqual(
+        actualElapsed,
+        expectedElapsed,
+        accuracy: 0.001,
+        "The refreshed lock-screen elapsed time must reflect the emitted position."
+      )
+    }
   }
 }

--- a/PalaceAudiobookToolkitTests/BearerTokenRefreshTests.swift
+++ b/PalaceAudiobookToolkitTests/BearerTokenRefreshTests.swift
@@ -325,8 +325,13 @@ final class ManifestOriginHostTests: XCTestCase {
     }
 
     func testOriginHost_noSelfLink_returnsNil() throws {
+        // `dracula_manifest` has an empty `links` array (no `self` relation), so
+        // the token scope host cannot be derived and must be nil. The previous
+        // fixture (`bocas_manifest`) actually carries a `self` link to
+        // catalog.biblioboard.com, so it asserted the opposite of its name and
+        // never exercised the no-self-link path.
         let manifest = try Manifest.from(
-            jsonFileName: "bocas_manifest",
+            jsonFileName: "dracula_manifest",
             bundle: Bundle(for: ManifestOriginHostTests.self)
         )
         XCTAssertNil(manifest.originHost,

--- a/PalaceAudiobookToolkitTests/PlayerMock.swift
+++ b/PalaceAudiobookToolkitTests/PlayerMock.swift
@@ -28,6 +28,13 @@ class PlayerMock: NSObject, Player {
     positionSubject.eraseToAnyPublisher()
   }
 
+  /// Test seam: pump the fast-position stream that AVPlayer's periodic time
+  /// observer feeds in production. Lets a test drive the manager's
+  /// `positionPublisher`-based lock-screen heartbeat deterministically.
+  func _emitPosition(_ position: PalaceAudiobookToolkit.TrackPosition) {
+    positionSubject.send(position)
+  }
+
   required init(tableOfContents: PalaceAudiobookToolkit.AudiobookTableOfContents) {
     self.tableOfContents = tableOfContents
     playbackStatePublisher = PassthroughSubject()


### PR DESCRIPTION
## Summary
Fixes the **"NowPlayingCoordinator dry while isPlaying"** regression (HelpSpot 17865 / Crashlytics code **403** — ~23k events / 2,179 users through 3.2.3).

The lock-screen / now-playing writer was refreshed **only** by a main-runloop `Timer.publish(in: .common)`. iOS coalesces/suspends such timers during long screen-locked background playback, so `MPNowPlayingInfoCenter` went dry >30s while audio kept playing. The prior HelpSpot-17865 mitigation (rebuild the timer at 15s on background entry) didn't close it because the mechanism itself is unreliable in the background.

**Fix:** also drive `updateNowPlayingInfo` from the player's `positionPublisher` — the AVPlayer periodic-time observer the OS guarantees to fire during playback (including backgrounded/locked), rate-limited to a 2s lock-screen cadence. Lock-screen only; the in-app slider already subscribes to `positionPublisher`, so the slider path and the foreground resume-jump fix are untouched.

## Tests
- New `AudiobookManagerLifecycleTests.testPositionPublisher_refreshesLockScreen_whenWallClockTimerSilent` — cancels the wall-clock timer (the background case), emits a position, asserts the lock screen refreshes. **Mutation-verified**: with the fix disabled it fails on its assertion.
- Fixes two **pre-existing, unrelated** suite failures found along the way:
  - `ManifestOriginHostTests.testOriginHost_noSelfLink_returnsNil` used `bocas_manifest`, which actually carries a `self` link → repointed to `dracula_manifest` (empty links).
  - `AudiobookAccessibilityAnnouncementCenterTests` progress-throttle test was stale after `0d739944` silenced intermediate progress announcements → rewritten to pin the current contract.
- **Full `PalaceAudiobookToolkitTests`: 169 tests, 0 failures, 1 documented skip.**

## Verification caveat
The unit test proves the *mechanism*. The real-world background dry-stream reduction (runloop coalescing over a long locked session) can't be reproduced on the simulator and should get one on-device confirmation before/with the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)